### PR TITLE
correct order for [blockpergrid, threadperblock] for CUDA function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,8 @@ from larndsim import quenching, drifting
 
 threadsperblock = 256
 blockspergrid = ceil(tracks.shape[0] / threadsperblock)
-quenching.quench[threadsperblock,blockspergrid](tracks, consts.box)
-drifting.drift[threadsperblock,blockspergrid](tracks)
+quenching.quench[blockspergrid,threadsperblock](tracks, consts.box)
+drifting.drift[blockspergrid,threadsperblock](tracks)
 ```
 
 ### Pixel simulation stage
@@ -41,7 +41,7 @@ First, we find the pixels interesected by the projection of each track segment o
 ```python
 from larndsim import pixels_from_track
 ...
-pixels_from_track.get_pixels[threadsperblock,blockspergrid](segments,
+pixels_from_track.get_pixels[blockspergrid,threadsperblock](segments,
                                                             active_pixels,
                                                             neighboring_pixels,
                                                             n_pixels_list)
@@ -52,7 +52,7 @@ Finally, we calculate the current induced on each pixel using the `tracks_curren
 ```python
 from larndsim import detsim
 ...
-detsim.tracks_current[threadsperblock, blockspergrid](signals,
+detsim.tracks_current[blockspergrid,threadsperblock](signals,
                                                       neighboring_pixels,
                                                       segments)
 ```
@@ -66,7 +66,7 @@ from larndsim import detsim
 ...
 max_length = np.array([0])
 track_starts = np.empty(segments.shape[0])
-detsim.time_intervals[threadsperblock, blockspergrid](track_starts,
+detsim.time_intervals[blockspergrid,threadsperblock](track_starts,
                                                       max_length,
                                                       segments)
 ```

--- a/tests/testDrifting.py
+++ b/tests/testDrifting.py
@@ -34,6 +34,6 @@ class TestDrifting:
 
         TPB = 128
         BPG = ceil(tracks.shape[0] / TPB)
-        drifting.drift[TPB,BPG](tracks)
+        drifting.drift[BPG,TPB](tracks)
 
         assert tracks[:, i.n_electrons] == pytest.approx(electronsAtAnode)

--- a/tests/testQuenching.py
+++ b/tests/testQuenching.py
@@ -28,7 +28,7 @@ class TestQuenching:
         de = self.tracks[:, i.dE]
         TPB = 128
         BPG = ceil(tracks_birks.shape[0] / TPB)
-        quenching.quench[TPB,BPG](tracks_birks, consts.birks)
+        quenching.quench[BPG,TPB](tracks_birks, consts.birks)
 
         nelectrons = tracks_birks[:, i.n_electrons]
 
@@ -43,7 +43,7 @@ class TestQuenching:
         de = self.tracks[:, i.dE]
         TPB = 128
         BPG = ceil(tracks_box.shape[0] / TPB)
-        quenching.quench[TPB,BPG](tracks_box, consts.box)
+        quenching.quench[BPG,TPB](tracks_box, consts.box)
 
         csi = consts.beta * dedx / (consts.eField * consts.lArDensity)
         recomb = np.log(consts.alpha + csi)/csi


### PR DESCRIPTION
correct order for [blockpergrid, threadperblock] for CUDA function calls in README.md,  tests/testDrifting.py and tests/testQuenching.py