### PR TITLE
Add adc busy delay to trigger logic

### DIFF
--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -22,7 +22,7 @@ DISCRIMINATION_THRESHOLD = 7e3*consts.e_charge
 #: ADC hold delay in clock cycles
 ADC_HOLD_DELAY = 15
 #: ADC busy delay in clock cycles
-ADC_BUSY_DELAY = 9
+ADC_BUSY_DELAY = 8
 #: Reset time in clock cycles
 RESET_CYCLES = 1
 #: Clock cycle time in :math:`\mu s`


### PR DESCRIPTION
 - Adds a trigger delay (without charge loss) after the successful trigger of the front end to better reflect the true trigger logic.
 - Promotes the dead time to a constant configurable (`RESET_CYCLES`), which does not impact simulation results
