### PR TITLE
Add new far-field model

### DIFF
--- a/larndsim/bin/response_44-far_field-v2.npy
+++ b/larndsim/bin/response_44-far_field-v2.npy
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:0f1fd0ef33cc1778c8f520ae5c998d80d7fdbd31cac5afbed989880567b9bc70
-size 30634328

--- a/larndsim/bin/response_44-far_field-v2.npy
+++ b/larndsim/bin/response_44-far_field-v2.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:0f1fd0ef33cc1778c8f520ae5c998d80d7fdbd31cac5afbed989880567b9bc70
+size 30634328

--- a/larndsim/bin/response_44-far_field.npy
+++ b/larndsim/bin/response_44-far_field.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:e5bae5b5595c121035e077052dd63344b657a1d250fa8f910845248e45e0603c
+oid sha256:0f1fd0ef33cc1778c8f520ae5c998d80d7fdbd31cac5afbed989880567b9bc70
 size 30634328


### PR DESCRIPTION
Adds an updated far-field model (`response_44-far_field-v2.npy`) that uses a different normalization scheme that produces better results when compared to Module 0 data