### PR TITLE
Allow for arbitrary sipm response models

### DIFF
--- a/larndsim/bin/light_noise.npy
+++ b/larndsim/bin/light_noise.npy
@@ -1,3 +1,3 @@
 version https://git-lfs.github.com/spec/v1
-oid sha256:f78e7dfdde8e407f38e8c1bea0b07138cd151bfea628ff3a2fc9e6db8801c696
+oid sha256:66d5222b9006673dc9accfc6b86f14687d65f778d859d0d19da101c5215c6cde
 size 99200

--- a/larndsim/bin/sipm_impulse.npy
+++ b/larndsim/bin/sipm_impulse.npy
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:f0c04165d1f7e01a20ef229d15c438ced82036150d9c156786356a82f34d61e6
+size 2176

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -3,6 +3,7 @@ Sets ligth-related constants
 """
 import yaml
 import numpy as np
+import os
 
 LUT_VOX_DIV = np.zeros(0)
 N_OP_CHANNEL = 0
@@ -15,7 +16,7 @@ SCINT_PRESCALE = 1
 W_PH = 19.5e-6 # MeV
 
 #: Step size for light simulation [microseconds]
-LIGHT_TICK_SIZE = 0.001 # us
+LIGHT_TICK_SIZE = 0.005 # us
 #: Pre- and post-window for light simulation [microseconds]
 LIGHT_WINDOW = (1, 10) # us
 
@@ -24,16 +25,22 @@ SINGLET_FRACTION = 0.3
 #: Singlet decay time [microseconds]
 TAU_S = 0.001 # us
 #: Triplet decay time [microseconds]
-TAU_T = 1.530
+TAU_T = 1.530 # us
 
 #: Conversion from PE/microsecond to ADC
 LIGHT_GAIN = -2.30 # ADC * us/PE
+#: Set response model type (0=RLC response, 1=arbitrary input)
+SIPM_RESPONSE_MODEL = 0
 #: Response RC time [microseconds]
 LIGHT_RESPONSE_TIME = 0.055
 #: Reponse oscillation period [microseconds]
 LIGHT_OSCILLATION_PERIOD = 0.095
 #: Sample rate for input noise spectrum [microseconds]
 LIGHT_DET_NOISE_SAMPLE_SPACING = 0.01 # us
+#: Arbitrary input model (normalized to sum of 1)
+IMPULSE_MODEL = np.array([1,0])
+#: Arbitrary input model tick size [microseconds]
+IMPULSE_TICK_SIZE = 0.001
 
 #: Total detector light threshold [ADC]
 LIGHT_TRIG_THRESHOLD = -10000
@@ -65,11 +72,14 @@ def set_light_properties(detprop_file):
     global SINGLET_FRACTION
     global TAU_S
     global TAU_T
-    
+
     global LIGHT_GAIN
+    global SIPM_RESPONSE_MODEL
     global LIGHT_RESPONSE_TIME
     global LIGHT_OSCILLATION_PERIOD
     global LIGHT_DET_NOISE_SAMPLE_SPACING
+    global IMPULSE_MODEL
+    global IMPULSE_TICK_SIZE
 
     global LIGHT_TRIG_THRESHOLD
     global LIGHT_TRIG_WINDOW
@@ -103,9 +113,16 @@ def set_light_properties(detprop_file):
         if LIGHT_GAIN.size == 1:
             LIGHT_GAIN = np.full(OP_CHANNEL_EFFICIENCY.shape, LIGHT_GAIN)
         assert LIGHT_GAIN.shape == OP_CHANNEL_EFFICIENCY.shape
+        SIPM_RESPONSE_MODEL = int(detprop.get('sipm_response_model', SIPM_RESPONSE_MODEL))
+        assert SIPM_RESPONSE_MODEL in (0,1)
         LIGHT_DET_NOISE_SAMPLE_SPACING = float(detprop.get('light_det_noise_sample_spacing', LIGHT_DET_NOISE_SAMPLE_SPACING))
         LIGHT_RESPONSE_TIME = float(detprop.get('light_response_time', LIGHT_RESPONSE_TIME))
         LIGHT_OSCILLATION_PERIOD = float(detprop.get('light_oscillation_period', LIGHT_OSCILLATION_PERIOD))
+        impulse_model_filename = str(detprop.get('impulse_model', ''))
+        if impulse_model_filename and SIPM_RESPONSE_MODEL == 1:
+            print('Light impulse model:', impulse_model_filename)
+            IMPULSE_MODEL = np.load(os.path.join(os.path.dirname(__file__), '../../') + impulse_model_filename)
+        IMPULSE_TICK_SIZE = float(detprop.get('impulse_tick_size', IMPULSE_TICK_SIZE))
 
         LIGHT_TRIG_THRESHOLD = float(detprop.get('light_trig_threshold', LIGHT_TRIG_THRESHOLD))
         LIGHT_TRIG_WINDOW = tuple(detprop.get('light_trig_window', LIGHT_TRIG_WINDOW))

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -121,7 +121,12 @@ def set_light_properties(detprop_file):
         impulse_model_filename = str(detprop.get('impulse_model', ''))
         if impulse_model_filename and SIPM_RESPONSE_MODEL == 1:
             print('Light impulse model:', impulse_model_filename)
-            IMPULSE_MODEL = np.load(os.path.join(os.path.dirname(__file__), '../../') + impulse_model_filename)
+            try:
+                # first try to load from current directory
+                IMPULSE_MODEL = np.load(impulse_model_filename)
+            except FILENotFoundError:
+                # then try from larnd-sim base directory
+                IMPULSE_MODEL = np.load(os.path.join(os.path.dirname(__file__), '../../') + impulse_model_filename)
         IMPULSE_TICK_SIZE = float(detprop.get('impulse_tick_size', IMPULSE_TICK_SIZE))
 
         LIGHT_TRIG_THRESHOLD = float(detprop.get('light_trig_threshold', LIGHT_TRIG_THRESHOLD))

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -124,7 +124,7 @@ def set_light_properties(detprop_file):
             try:
                 # first try to load from current directory
                 IMPULSE_MODEL = np.load(impulse_model_filename)
-            except FILENotFoundError:
+            except FileNotFoundError:
                 # then try from larnd-sim base directory
                 IMPULSE_MODEL = np.load(os.path.join(os.path.dirname(__file__), '../../') + impulse_model_filename)
         IMPULSE_TICK_SIZE = float(detprop.get('impulse_tick_size', IMPULSE_TICK_SIZE))

--- a/larndsim/detector_properties/module0.yaml
+++ b/larndsim/detector_properties/module0.yaml
@@ -6,7 +6,7 @@ long_diff: 4.0e-6 # cm * cm / us
 tran_diff: 8.8e-6 # cm * cm / us
 singlet_fraction: 0.3
 tau_s: 0.001 # us
-tau_t: 1.530 # us
+tau_t: 0.752 # us
 
 # Charge simulation parameters
 drift_length: 30.27225 # cm
@@ -26,7 +26,10 @@ module_to_io_groups:
   1: [1,2,3,4]
 
 # Light simulation parameters
-light_gain: -2.30 # ADC us / PE
+light_gain: -2.40 # ADC us / PE
+sipm_response_model: 1 # arbitrary impulse
+impulse_model: 'larndsim/bin/sipm_impulse.npy'
+impulse_tick_size: 0.01 # us
 light_det_noise_sample_spacing: 0.01 # us
 light_trig_threshold: -10000 # ADC
 light_trig_window: [0.9, 1.66] # us

--- a/larndsim/lightLUT.py
+++ b/larndsim/lightLUT.py
@@ -52,7 +52,7 @@ def get_voxel(pos, itpc):
         # rather than the xMin side as means of rotating the x component
         i = int((x_max - pos[0])/(x_max - x_min) * LUT_VOX_DIV[0])
 
-    j = int((pos[1] - y_min)/(y_max - y_min) * LUT_VOX_DIV[1])
+    j = int((y_max - pos[1])/(y_max - y_min) * LUT_VOX_DIV[1])
     k = int((pos[2] - z_min)/(z_max - z_min) * LUT_VOX_DIV[2])
 
     return i, j, k


### PR DESCRIPTION
Allows the SiPM response model to be specified in an array rather than just the RLC impulse response.

Also updates the module 0 default parameters and noise model, fixes a bug in the LUT indexing, fixes a bug in the poisson statistics generation, and handles a few edge cases better.