### PR TITLE
Prevent out of range indexing

### DIFF
--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -556,8 +556,9 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
 
             if itick < signals.shape[2]:
                 itime = start_tick + itick
-                cuda.atomic.add(pixels_signals, (pixel_index, itime), signals[itrk][ipix][itick])
-                cuda.atomic.add(pixels_tracks_signals, (pixel_index, itime, counter), signals[itrk][ipix][itick])
+                if itime < pixels_signals.shape[1]:
+                    cuda.atomic.add(pixels_signals, (pixel_index, itime), signals[itrk][ipix][itick])
+                    cuda.atomic.add(pixels_tracks_signals, (pixel_index, itime, counter), signals[itrk][ipix][itick])
 
 @cuda.jit
 def get_track_pixel_map(track_pixel_map, unique_pix, pixels):


### PR DESCRIPTION
It is possible to have an invalid time index in the atomic add in `sum_pixel_signals`. This happens fairly frequently but there is no runtime error when the index is only slightly out of range. For an event with a track with a very late start tick (event 15 of `/dune/data2/users/awilkins/extrapolation/nd_cafs/edep/0m/00/FHC.1000000.edep.h5`) I get a cuda runtime error. `cuda-gdb` with memcheck switched on pointed to these atomic adds as the cause.