### PR TITLE
a way to avoid duplicate cupy installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,5 @@
 #!/usr/bin/env python
 
-import setuptools
-
 VER = "0.3.1"
 
 reqs = ["numpy", "pytest", "numba==0.52", "larpix-control", "larpix-geometry", "tqdm", "fire"]
@@ -18,6 +16,15 @@ try:
     print(msg % (str(cupy.__version__),str(cupy.__file__)))
 except ImportError:
     reqs.append('cupy')
+
+import os
+if 'SKIP_CUPY_INSTALL' in os.environ:
+    try:
+        _ = reqs.pop(reqs.index('cupy'))
+    except ValueError:
+        pass
+
+import setuptools
 
 setuptools.setup(
     name="larndsim",

--- a/setup.py
+++ b/setup.py
@@ -4,6 +4,21 @@ import setuptools
 
 VER = "0.3.1"
 
+reqs = ["numpy", "pytest", "numba==0.52", "larpix-control", "larpix-geometry", "tqdm", "fire"]
+
+try:
+    import cupy
+    msg = '''
+    ############ INFORMATION ############
+    Detected and using the installed cupy
+    Version: %s
+    Source : %s
+    #####################################\n
+    '''
+    print(msg % (str(cupy.__version__),str(cupy.__file__)))
+except ImportError:
+    reqs.append('cupy')
+
 setuptools.setup(
     name="larndsim",
     version=VER,
@@ -13,7 +28,7 @@ setuptools.setup(
     url="https://github.com/DUNE/larnd-sim",
     packages=setuptools.find_packages(),
     scripts=["cli/simulate_pixels.py", "cli/dumpTree.py"],
-    install_requires=["numpy", "pytest", "numba>=0.52", "larpix-control", "larpix-geometry", "tqdm", "fire", "cupy"],
+    install_requires=reqs,
     classifiers=[
         "Development Status :: 2 - Pre-Alpha",
         "Intended Audience :: by End-User Class :: Developers",


### PR DESCRIPTION
Detect whether `cupy` is already installed or not, and only add `cupy` to requirements if not installed. The issue is that `cupy` may be installed in multiple ways and not all methods let pip to detect it. Plus, `cupy` gets unhappy when two versions are installed. So add a manual check by an import attempt. I actually had this modification for long time in the fork, but I don't want to maintain a fork just for this (and it should be useful and harmless)