### PR TITLE
Make simulate_pixels.py more robust against huge tracks datasets

### DIFF
--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -24,7 +24,7 @@ segments_dtype = np.dtype([("eventID", "u4"), ("segment_id", "u4"), ("z_end", "f
                            ("pixel_plane", "i4"), ("t_end", "f4"),
                            ("dEdx", "f4"), ("dE", "f4"), ("t", "f4"),
                            ("y", "f4"), ("x", "f4"), ("z", "f4"),
-                           ("n_photons","f4")])
+                           ("n_photons","f4")], align=True)
 
 trajectories_dtype = np.dtype([("eventID", "u4"), ("trackID", "u4"),
                                ("parentID", "i4"),
@@ -35,9 +35,9 @@ trajectories_dtype = np.dtype([("eventID", "u4"), ("trackID", "u4"),
                                ("pdgId", "i4"), ("start_process", "u4"),
                                ("start_subprocess", "u4"),
                                ("end_process", "u4"),
-                               ("end_subprocess", "u4")])
+                               ("end_subprocess", "u4")], align=True)
 
-vertices_dtype = np.dtype([("eventID","u4"),("x_vert","f4"),("y_vert","f4"),("z_vert","f4")])
+vertices_dtype = np.dtype([("eventID","u4"),("x_vert","f4"),("y_vert","f4"),("z_vert","f4")], align=True)
 
 # Convert from EDepSim default units (mm, ns)
 edep2cm = 0.1   # convert to cm

--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 from ROOT import TG4Event, TFile
 
 # Output array datatypes
-segments_dtype = np.dtype([("eventID", "u4"), ("z_end", "f4"),
+segments_dtype = np.dtype([("eventID", "u4"), ("segment_id", "u4"), ("z_end", "f4"),
                            ("trackID", "u4"), ("tran_diff", "f4"),
                            ("z_start", "f4"), ("x_end", "f4"),
                            ("y_end", "f4"), ("n_electrons", "u4"),
@@ -180,6 +180,7 @@ def dump(input_file, output_file):
     trajectories_list = list()
     vertices_list = list()
 
+    segment_id = 0
     for jentry in tqdm(range(entries)):
         #print(jentry)
         nb = inputTree.GetEntry(jentry)
@@ -242,6 +243,8 @@ def dump(input_file, output_file):
             segment = np.empty(len(hitSegments), dtype=segments_dtype)
             for iHit, hitSegment in enumerate(hitSegments):
                 segment[iHit]["eventID"] = event.EventId
+                segment[iHit]["segment_id"] = segment_id
+                segment_id += 1
                 segment[iHit]["trackID"] = trajectories[hitSegment.Contrib[0]]["trackID"]
                 segment[iHit]["x_start"] = hitSegment.GetStart().X() * edep2cm
                 segment[iHit]["y_start"] = hitSegment.GetStart().Y() * edep2cm

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -439,7 +439,7 @@ def run_simulation(input_filename,
             signals = cp.zeros((selected_tracks.shape[0],
                                 neighboring_pixels.shape[1],
                                 cp.asnumpy(max_length)[0]), dtype=np.float32)
-            TPB = (8,8,8)
+            TPB = (1,1,64)
             BPG_X = ceil(signals.shape[0] / TPB[0])
             BPG_Y = ceil(signals.shape[1] / TPB[1])
             BPG_Z = ceil(signals.shape[2] / TPB[2])

--- a/larndsim/active_volume.py
+++ b/larndsim/active_volume.py
@@ -1,0 +1,34 @@
+import numpy as np
+import cupy as cp
+
+def select_active_volume(track_seg, tpc_borders):
+    """
+    Extracts track segments that are within the described TPC borders
+
+    Args:
+        track_seg (:obj:`numpy.ndarray`): edep-sim track segment array
+        tpc_borders (:obj:`numpy.ndarray`): bounding box of each tpc, shape `(ntpc, 3, 2)`
+
+    Returns:
+        indices of track segments that are at least partially contained
+    """
+    xp = cp.get_array_module(track_seg)
+    tpc_mask = xp.zeros(track_seg.shape, dtype=bool)
+    tpb_borders = xp.sort(tpc_borders, axis=-1)
+    for i_tpc in range(tpc_borders.shape[0]):
+        tpc_bound = tpc_borders[i_tpc]
+        tpc_mask = tpc_mask | (
+                ((track_seg['x_end'] > tpc_bound[0,0])
+                 & (track_seg['x_end'] < tpc_bound[0,1])
+                 & (track_seg['y_end'] > tpc_bound[1,0])
+                 & (track_seg['y_end'] < tpc_bound[1,1])
+                 & (track_seg['z_end'] > tpc_bound[2,0])
+                 & (track_seg['z_end'] < tpc_bound[2,1]))
+                | ((track_seg['x_start'] > tpc_bound[0,0])
+                   & (track_seg['x_start'] < tpc_bound[0,1])
+                   & (track_seg['y_start'] > tpc_bound[1,0])
+                   & (track_seg['y_start'] < tpc_bound[1,1])
+                   & (track_seg['z_start'] > tpc_bound[2,0])
+                   & (track_seg['z_start'] < tpc_bound[2,1])))
+
+    return xp.nonzero(tpc_mask)[0]


### PR DESCRIPTION
 - Filters tracks dataset against declared active TPCs
 - Restructures simulate_pixels.py to create a minimal memory footprint prior to filtering tracks dataset
 - Add segment_id to tracks dataset in order to preserve MC truth backtracking

For the 2x2 file that @krwood provided me, I no longer encounter memory overruns on a single CORI 16GB Tesla V100 gpu with a `tracks` dataset containing 20M entries.

The tracks dataset is still loaded up front which takes approx ~30s. The dataset is then filtered on the CPU (~20s), which could probably be sped up by copying the xyz data to the GPU. The subsequent simulation then only takes about another 20s.