### PR TITLE
Load the light LUT in to device memory once, rather than transfer on each batch

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -142,7 +142,7 @@ def run_simulation(input_filename,
     RangePush("load_larndsim_modules")
     # Here we load the modules after loading the detector properties
     # maybe can be implemented in a better way?
-    from larndsim import (quenching, drifting, detsim, pixels_from_track, fee,
+    from larndsim import (active_volume, quenching, drifting, detsim, pixels_from_track, fee,
         lightLUT, light_sim)
     RangePop()
 
@@ -155,9 +155,22 @@ def run_simulation(input_filename,
     RangePop()
 
     RangePush("load_hd5_file")
+    print("Loading track segments..." , end="")
+    start_load = time()
     # First of all we load the edep-sim output
     with h5py.File(input_filename, 'r') as f:
         tracks = np.array(f['segments'])
+        if 'segment_id' in tracks.dtype.names:
+            track_ids = tracks['segment_id']
+        else:
+            dtype = tracks.dtype.descr
+            dtype = [('segment_id','u4')] + dtype
+            new_tracks = np.empty(tracks.shape, dtype=np.dtype(dtype, align=True))
+            new_tracks['segment_id'] = np.arange(tracks.shape[0], dtype='u4')
+            for field in dtype[1:]:
+                new_tracks[field[0]] = tracks[field[0]]
+            tracks = new_tracks
+            track_ids = tracks['segment_id']
         try:
             trajectories = np.array(f['trajectories'])
             input_has_trajectories = True
@@ -171,29 +184,48 @@ def run_simulation(input_filename,
             print("Input file does not have true vertices info")
             input_has_vertices = False
 
-    RangePop()
-
-    # Makes an empty array to store data from lightlut
-    if light.LIGHT_SIMULATED:
-        light_sim_dat = np.zeros([len(tracks), light.N_OP_CHANNEL],
-                                 dtype=[('n_photons_det','f4'),('t0_det','f4')])
-        track_light_voxel = np.zeros([len(tracks), 3], dtype='i4')
-
     if tracks.size == 0:
         print("Empty input dataset, exiting")
         return
+    
+    RangePop()
+    end_load = time()
+    print(f" {end_load-start_load:.2f} s")
 
+    response = cp.load(response_file)
+
+    TPB = 256
+    BPG = ceil(tracks.shape[0] / TPB)
+
+    print("******************\nRUNNING SIMULATION\n******************")
+    # Reduce dataset if not all tracks to be simulated
     if n_tracks:
         tracks = tracks[:n_tracks]
-        if light.LIGHT_SIMULATED:
-            light_sim_dat = light_sim_dat[:n_tracks]
-            track_light_voxel = track_light_voxel[:n_tracks]
+
+    # Here we swap the x and z coordinates of the tracks
+    # because of the different convention in larnd-sim wrt edep-sim
+    tracks = swap_coordinates(tracks)
+
+    # Sub-select only segments in active volumes
+    print("Skipping non-active volumes..." , end="")
+    start_mask = time()
+    active_tracks = active_volume.select_active_volume(tracks, detector.TPC_BORDERS)
+    tracks = tracks[active_tracks]
+    track_ids = track_ids[active_tracks]
+    end_mask = time()
+    print(f" {end_mask-start_mask:.2f} s")
+
+    # Set up light simulation data objects
+    if light.LIGHT_SIMULATED:
+        light_sim_dat = np.zeros([len(tracks), light.N_OP_CHANNEL],
+                                 dtype=[('segment_id', 'u4'), ('n_photons_det','f4'),('t0_det','f4')])
+        light_sim_dat['segment_id'] = track_ids[..., np.newaxis]
+        track_light_voxel = np.zeros([len(tracks), 3], dtype='i4')
 
     if 'n_photons' not in tracks.dtype.names:
         n_photons = np.zeros(tracks.shape[0], dtype=[('n_photons', 'f4')])
         tracks = rfn.merge_arrays((tracks, n_photons), flatten=True)
-
-
+        
     if 't0' not in tracks.dtype.names:
         # the t0 key refers to the time of energy deposition
         # in the input files, it is called 't'
@@ -209,16 +241,6 @@ def run_simulation(input_filename,
         tracks['t_start'] = np.zeros(tracks.shape[0], dtype=[('t_start', 'f4')])
         tracks['t_end'] = np.zeros(tracks.shape[0], dtype=[('t_end', 'f4')])
 
-    # Here we swap the x and z coordinates of the tracks
-    # because of the different convention in larnd-sim wrt edep-sim
-    tracks = swap_coordinates(tracks)
-
-    response = cp.load(response_file)
-
-    TPB = 256
-    BPG = max(ceil(tracks.shape[0] / TPB),1)
-
-    print("******************\nRUNNING SIMULATION\n******************")
     # We calculate the number of electrons after recombination (quenching module)
     # and the position and number of electrons after drifting (drifting module)
     print("Quenching electrons..." , end="")
@@ -241,7 +263,9 @@ def run_simulation(input_filename,
         # clip LUT so that no voxel contains 0 visibility
         mask = lut['vis'] > 0
         lut['vis'][~mask] = lut['vis'][mask].min()
+
         lut = to_device(lut)
+        
         light_noise = cp.load(light_det_noise_filename)
         
         TPB = 256
@@ -249,6 +273,7 @@ def run_simulation(input_filename,
         lightLUT.calculate_light_incidence[BPG,TPB](tracks, lut, light_sim_dat, track_light_voxel)
         print(f" {time()-start_light_time:.2f} s")
 
+    # prep output file with truth datasets
     with h5py.File(output_filename, 'a') as output_file:
         output_file.create_dataset("tracks", data=tracks)
         if light.LIGHT_SIMULATED:
@@ -264,6 +289,8 @@ def run_simulation(input_filename,
     _, _, rev_idx = np.intersect1d(tot_evids, tracks[EVENT_SEPARATOR][::-1], return_indices=True)
     end_idx = len(tracks[EVENT_SEPARATOR]) - 1 - rev_idx
     track_ids = cp.array(np.arange(len(tracks)), dtype='i4')
+    # copy to device
+    track_ids = cp.asarray(track_ids)
 
     # create a lookup table for event timestamps
     event_times = fee.gen_event_times(tot_evids.max()+1, 0)
@@ -373,7 +400,7 @@ def run_simulation(input_filename,
             max_radius = ceil(max(selected_tracks["tran_diff"])*5/detector.PIXEL_PITCH)
 
             TPB = 128
-            BPG = max(ceil(selected_tracks.shape[0] / TPB),1)
+            BPG = ceil(selected_tracks.shape[0] / TPB)
             max_pixels = np.array([0])
             pixels_from_track.max_pixels[BPG,TPB](selected_tracks, max_pixels)
 
@@ -417,10 +444,10 @@ def run_simulation(input_filename,
             signals = cp.zeros((selected_tracks.shape[0],
                                 neighboring_pixels.shape[1],
                                 cp.asnumpy(max_length)[0]), dtype=np.float32)
-            TPB = (8,8,8)
-            BPG_X = max(ceil(signals.shape[0] / TPB[0]),1)
-            BPG_Y = max(ceil(signals.shape[1] / TPB[1]),1)
-            BPG_Z = max(ceil(signals.shape[2] / TPB[2]),1)
+            TPB = (1,1,64)
+            BPG_X = ceil(signals.shape[0] / TPB[0])
+            BPG_Y = ceil(signals.shape[1] / TPB[1])
+            BPG_Z = ceil(signals.shape[2] / TPB[2])
             BPG = (BPG_X, BPG_Y, BPG_Z)
             rng_states = maybe_create_rng_states(int(np.prod(TPB[:2]) * np.prod(BPG[:2])), seed=SEED+ievd+itrk, rng_states=rng_states)
             detsim.tracks_current_mc[BPG,TPB](signals, neighboring_pixels, selected_tracks, response, rng_states)

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -535,7 +535,6 @@ def run_simulation(input_filename,
                 n_light_ticks = min(n_light_ticks,int(5E4))
                 op_channel = light_sim.get_active_op_channel(light_inc)
 
-                #n_light_det = light_inc.shape[-1]
                 n_light_det = op_channel.shape[0]
                 light_sample_inc = cp.zeros((n_light_det,n_light_ticks), dtype='f4')
                 light_sample_inc_true_track_id = cp.full((n_light_det, n_light_ticks, light.MAX_MC_TRUTH_IDS), -1, dtype='i8')

--- a/larndsim/lightLUT.py
+++ b/larndsim/lightLUT.py
@@ -109,10 +109,11 @@ def calculate_light_incidence(tracks, lut, light_incidence, voxel):
             # Assigns the LUT data to the light_incidence array
             for output_i in range(light.N_OP_CHANNEL):
                 op_channel_index = output_i
+                lut_index = output_i % vis_dat.shape[0]
             
                 eff = OP_CHANNEL_EFFICIENCY[output_i]
-                vis = vis_dat[output_i] * (OP_CHANNEL_TO_TPC[output_i] == itpc)
-                t1 = (T1_dat[output_i] * units.ns + tracks['t0'][itrk] * units.mus) / units.mus
+                vis = vis_dat[lut_index] * (OP_CHANNEL_TO_TPC[output_i] == itpc)
+                t1 = (T1_dat[lut_index] * units.ns + tracks['t0'][itrk] * units.mus) / units.mus
 
                 light_incidence['n_photons_det'][itrk,op_channel_index] = eff * vis * n_photons
                 light_incidence['t0_det'][itrk,op_channel_index] = t1

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -56,7 +56,7 @@ def get_active_op_channel(light_incidence):
     return cp.empty((0,), dtype='i4')
     
 @cuda.jit
-def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, lut, start_time, light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons):
+def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_channel, lut, start_time, light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons):
     """
     Sums the number of photons observed by each light detector at each time tick
 
@@ -65,7 +65,8 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, lut,
         segment_voxel(array): shape `(ntracks, 3)`, LUT voxel for eack edep-sim track
         segment_track_id(array): shape `(ntracks,)`, unique id for each track segment (for MC truth backtracking)
         light_inc(array): shape `(ntracks, ndet)`, number of photons incident on each detector and voxel id
-        lut(array): shape `(nx,ny,nz)`, light look up table
+        op_channel(array): shape `(ntracks, ndet_active)`, optical channel index, will use lut[:,:,:,op_channel%lut.shape[3]] to look up timing information
+        lut(array): shape `(nx,ny,nz,ndet_tpc)`, light look up table
         start_time(float): start time of light simulation in microseconds
         light_sample_inc(array): output array, shape `(ndet, nticks)`, number of photons incident on each detector at each time tick (propogation delay only)
         light_sample_inc_true_track_id(array): output array, shape `(ndet, nticks, maxtracks)`, true track ids on each detector at each time tick (propogation delay only)
@@ -82,8 +83,10 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, lut,
             # find tracks that contribute light to this time tick
             for itrk in range(segments.shape[0]):
                 if light_inc[itrk,idet]['n_photons_det'] > 0:
+                    idet_lut = op_channel[idet] % lut.shape[3]
+                    
                     voxel = segment_voxel[itrk]
-                    time_profile = lut[voxel[0],voxel[1],voxel[2],idet]['time_dist']
+                    time_profile = lut[voxel[0],voxel[1],voxel[2],idet_lut]['time_dist']
                     track_time = segments[itrk]['t0']
                     track_end_time = track_time + time_profile.shape[0] * units.ns / units.mus # FIXME: assumes light LUT time profile bins are 1ns (might not be true in general)
 

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -81,10 +81,9 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
             end_tick_time = start_tick_time + LIGHT_TICK_SIZE
 
             # find tracks that contribute light to this time tick
+            idet_lut = op_channel[idet] % lut.shape[3]
             for itrk in range(segments.shape[0]):
-                if light_inc[itrk,idet]['n_photons_det'] > 0:
-                    idet_lut = op_channel[idet] % lut.shape[3]
-                    
+                if light_inc[itrk,idet_lut]['n_photons_det'] > 0:
                     voxel = segment_voxel[itrk]
                     time_profile = lut[voxel[0],voxel[1],voxel[2],idet_lut]['time_dist']
                     track_time = segments[itrk]['t0']
@@ -104,7 +103,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
                         for iprof in range(time_profile.shape[0]):
                             profile_time = track_time + iprof * units.ns / units.mus # FIXME: assumes light LUT time profile bins are 1ns (might not be true in general)
                             if profile_time < end_tick_time and profile_time > start_tick_time:
-                                photons = light_inc['n_photons_det'][itrk,idet] * time_profile[iprof] / norm / LIGHT_TICK_SIZE
+                                photons = light_inc['n_photons_det'][itrk,idet_lut] * time_profile[iprof] / norm / LIGHT_TICK_SIZE
                                 light_sample_inc[idet,itick] += photons
 
                                 if photons > MC_TRUTH_THRESHOLD:
@@ -127,7 +126,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
                         # add photons to time tick
                         profile_time = track_time + avg
                         if profile_time < end_tick_time and profile_time > start_tick_time:
-                            photons = light_inc['n_photons_det'][itrk,idet] / LIGHT_TICK_SIZE
+                            photons = light_inc['n_photons_det'][itrk,idet_lut] / LIGHT_TICK_SIZE
                             light_sample_inc[idet,itick] += photons
                             if photons > MC_TRUTH_THRESHOLD:
                                 # get truth information for time tick

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -83,7 +83,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
             # find tracks that contribute light to this time tick
             idet_lut = op_channel[idet] % lut.shape[3]
             for itrk in range(segments.shape[0]):
-                if light_inc[itrk,idet_lut]['n_photons_det'] > 0:
+                if light_inc[itrk,op_channel[idet]]['n_photons_det'] > 0:
                     voxel = segment_voxel[itrk]
                     time_profile = lut[voxel[0],voxel[1],voxel[2],idet_lut]['time_dist']
                     track_time = segments[itrk]['t0']
@@ -103,7 +103,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
                         for iprof in range(time_profile.shape[0]):
                             profile_time = track_time + iprof * units.ns / units.mus # FIXME: assumes light LUT time profile bins are 1ns (might not be true in general)
                             if profile_time < end_tick_time and profile_time > start_tick_time:
-                                photons = light_inc['n_photons_det'][itrk,idet_lut] * time_profile[iprof] / norm / LIGHT_TICK_SIZE
+                                photons = light_inc['n_photons_det'][itrk,op_channel[idet]] * time_profile[iprof] / norm / LIGHT_TICK_SIZE
                                 light_sample_inc[idet,itick] += photons
 
                                 if photons > MC_TRUTH_THRESHOLD:
@@ -126,7 +126,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
                         # add photons to time tick
                         profile_time = track_time + avg
                         if profile_time < end_tick_time and profile_time > start_tick_time:
-                            photons = light_inc['n_photons_det'][itrk,idet_lut] / LIGHT_TICK_SIZE
+                            photons = light_inc['n_photons_det'][itrk,op_channel[idet]] / LIGHT_TICK_SIZE
                             light_sample_inc[idet,itick] += photons
                             if photons > MC_TRUTH_THRESHOLD:
                                 # get truth information for time tick


### PR DESCRIPTION
The light LUT was accidentally being copied to the GPU on every batch iteration. This wasn't a performance driver, but the latest LUT from Livio is ~5GB, which if you copy on every iteration makes things very slow.

This PR changes the call signature of `sum_light_signals` to include a `op_channel` array which enables keeping the look up table in device memory.