### PR TITLE
Fix bug for overflow values

### DIFF
--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -309,7 +309,7 @@ def digitize(integral_list):
     """
     xp = cp.get_array_module(integral_list)
     adcs = xp.minimum(xp.around(xp.maximum((integral_list * GAIN + V_PEDESTAL - V_CM), 0)
-                                * ADC_COUNTS / (V_REF - V_CM)), ADC_COUNTS)
+                                * ADC_COUNTS / (V_REF - V_CM)), ADC_COUNTS-1)
 
     return adcs
 


### PR DESCRIPTION
A small bug that I found when investigating the nan values - if a pixel adc value becomes fully saturated, the adc value is clipped at 256. The data type in the output file is a 8bit unsigned int, so these clipped values end up rolling over back to 0. This fix makes it so they are correctly propagated to the output file with an ADC value of 255.