### PR TITLE
Fixing some naming/labeling inconsistencies

### DIFF
--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -14,11 +14,11 @@ import glob
 from ROOT import TG4Event, TFile, TMap
 
 # Output array datatypes
-segments_dtype = np.dtype([("eventID","u4"),("vertexID", "u8"), ("segment_id", "u4"),
-                           ("z_end", "f4"),("trackID", "u4"), ("tran_diff", "f4"),
+segments_dtype = np.dtype([("event_id","u4"),("vertex_id", "u8"), ("segment_id", "u4"),
+                           ("z_end", "f4"),("traj_id", "u4"), ("tran_diff", "f4"),
                            ("z_start", "f4"), ("x_end", "f4"),
                            ("y_end", "f4"), ("n_electrons", "u4"),
-                           ("pdgId", "i4"), ("x_start", "f4"),
+                           ("pdg_id", "i4"), ("x_start", "f4"),
                            ("y_start", "f4"), ("t_start", "f4"),
                            ("t0_start", "f8"), ("t0_end", "f8"), ("t0", "f8"),
                            ("dx", "f4"), ("long_diff", "f4"),
@@ -27,17 +27,17 @@ segments_dtype = np.dtype([("eventID","u4"),("vertexID", "u8"), ("segment_id", "
                            ("y", "f4"), ("x", "f4"), ("z", "f4"),
                            ("n_photons","f4")], align=True)
 
-trajectories_dtype = np.dtype([("eventID","u4"), ("vertexID", "u8"),
-                               ("trackID", "u4"), ("local_trackID", "u4"), ("parentID", "i4"),
+trajectories_dtype = np.dtype([("event_id","u4"), ("vertex_id", "u8"),
+                               ("traj_id", "u4"), ("local_traj_id", "u4"), ("parent_id", "i4"),
                                ("pxyz_start", "f4", (3,)),
                                ("xyz_start", "f4", (3,)), ("t_start", "f4"),
                                ("pxyz_end", "f4", (3,)),
                                ("xyz_end", "f4", (3,)), ("t_end", "f4"),
-                               ("pdgId", "i4"), ("start_process", "u4"),
+                               ("pdg_id", "i4"), ("start_process", "u4"),
                                ("start_subprocess", "u4"), ("end_process", "u4"),
                                ("end_subprocess", "u4")], align=True)
 
-vertices_dtype = np.dtype([("eventID","u4"), ("vertexID","u8"),
+vertices_dtype = np.dtype([("event_id","u4"), ("vertex_id","u8"),
                            ("x_vert","f4"), ("y_vert","f4"), ("z_vert","f4"),
                            ("t_vert","f4"), ("t_event","f4")], align=True)
 
@@ -249,8 +249,8 @@ def dump(input_file, output_file):
         vertices = np.empty(len(event.Primaries), dtype=vertices_dtype)
         for iVtx, primaryVertex in enumerate(event.Primaries):
             #printPrimaryVertex("PP", primaryVertex)
-            vertices[iVtx]["eventID"] = event.EventId
-            vertices[iVtx]["vertexID"] = iVtx
+            vertices[iVtx]["event_id"] = event.EventId
+            vertices[iVtx]["vertex_id"] = iVtx
             vertices[iVtx]["x_vert"] = primaryVertex.GetPosition().X() * edep2cm
             vertices[iVtx]["y_vert"] = primaryVertex.GetPosition().Y() * edep2cm
             vertices[iVtx]["z_vert"] = primaryVertex.GetPosition().Z() * edep2cm
@@ -270,12 +270,12 @@ def dump(input_file, output_file):
             trackMap[trajectory.GetTrackId()] = fileTrackID
 
             start_pt, end_pt = trajectory.Points[0], trajectory.Points[-1]
-            trajectories[iTraj]["eventID"] = event.EventId
-            trajectories[iTraj]["vertexID"] = globalVertexID
+            trajectories[iTraj]["event_id"] = event.EventId
+            trajectories[iTraj]["vertex_id"] = globalVertexID
 
-            trajectories[iTraj]["trackID"] = fileTrackID
-            trajectories[iTraj]["local_trackID"] = trajectory.GetTrackId()
-            trajectories[iTraj]["parentID"] = -1 if trajectory.GetParentId() == -1 \
+            trajectories[iTraj]["traj_id"] = fileTrackID
+            trajectories[iTraj]["local_traj_id"] = trajectory.GetTrackId()
+            trajectories[iTraj]["parent_id"] = -1 if trajectory.GetParentId() == -1 \
                 else trackMap[trajectory.GetParentId()]
 
             trajectories[iTraj]["pxyz_start"] = (start_pt.GetMomentum().X(), start_pt.GetMomentum().Y(), start_pt.GetMomentum().Z())
@@ -288,7 +288,7 @@ def dump(input_file, output_file):
             trajectories[iTraj]["start_subprocess"] = start_pt.GetSubprocess()
             trajectories[iTraj]["end_process"] = end_pt.GetProcess()
             trajectories[iTraj]["end_subprocess"] = end_pt.GetSubprocess()
-            trajectories[iTraj]["pdgId"] = trajectory.GetPDGCode()
+            trajectories[iTraj]["pdg_id"] = trajectory.GetPDGCode()
 
         trajectories_list.append(trajectories)
 
@@ -299,12 +299,12 @@ def dump(input_file, output_file):
                 continue
             segment = np.empty(len(hitSegments), dtype=segments_dtype)
             for iHit, hitSegment in enumerate(hitSegments):
-                segment[iHit]["eventID"] = event.EventId
-                segment[iHit]["vertexID"] = globalVertexID
+                segment[iHit]["event_id"] = event.EventId
+                segment[iHit]["vertex_id"] = globalVertexID
                 segment[iHit]["segment_id"] = segment_id
                 segment_id += 1
                 try:
-                    segment[iHit]["trackID"] = trackMap[hitSegment.Contrib[0]]
+                    segment[iHit]["traj_id"] = trackMap[hitSegment.Contrib[0]]
                 except IndexError as e:
                     print(e)
                     print("iHit:",iHit)
@@ -333,7 +333,7 @@ def dump(input_file, output_file):
                 segment[iHit]["t0"] = (segment[iHit]["t0_start"] + segment[iHit]["t0_end"]) / 2.
                 segment[iHit]["t"] = 0
                 segment[iHit]["dEdx"] = hitSegment.GetEnergyDeposit() / dx if dx > 0 else 0
-                segment[iHit]["pdgId"] = trajectories[hitSegment.Contrib[0]]["pdgId"]
+                segment[iHit]["pdg_id"] = trajectories[hitSegment.Contrib[0]]["pdg_id"]
                 segment[iHit]["n_electrons"] = 0
                 segment[iHit]["long_diff"] = 0
                 segment[iHit]["tran_diff"] = 0

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -453,7 +453,7 @@ def run_simulation(input_filename,
         for key in list(results.keys()):
             results[key] = np.concatenate([cp.asnumpy(arr) for arr in results[key]], axis=0)
 
-        uniq_events = cp.asnumpy(np.unique(results[sim.EVENT_SEPARATOR]))
+        uniq_events = cp.asnumpy(np.unique(results['event_id']))
         uniq_event_times = cp.asnumpy(event_times[uniq_events % sim.MAX_EVENTS_PER_FILE])
         if light.LIGHT_SIMULATED:
             # prep arrays for embedded triggers in charge data stream
@@ -468,7 +468,7 @@ def run_simulation(input_filename,
             light_trigger_times = np.zeros_like(uniq_event_times)
             light_trigger_event_ids = uniq_events
 
-        fee.export_to_hdf5(results[sim.EVENT_SEPARATOR],
+        fee.export_to_hdf5(results['event_id'],
                            results['adc_tot'],
                            results['adc_tot_ticks'],
                            results['unique_pix'],
@@ -650,7 +650,7 @@ def run_simulation(input_filename,
             adc_event_ids = np.full(adc_list.shape, unique_eventIDs[0]) # FIXME: only works if looping on a single event
             RangePop()
 
-            results_acc[sim.EVENT_SEPARATOR].append(adc_event_ids)
+            results_acc['event_id'].append(adc_event_ids)
             results_acc['adc_tot'].append(adc_list)
             results_acc['adc_tot_ticks'].append(adc_ticks_list)
             results_acc['unique_pix'].append(unique_pix)
@@ -733,14 +733,14 @@ def run_simulation(input_filename,
                 results_acc['light_waveforms_true_track_id'].append(light_digit_signal_true_track_id)
                 results_acc['light_waveforms_true_photons'].append(light_digit_signal_true_photons)
         
-        if len(results_acc[sim.EVENT_SEPARATOR]) >= sim.WRITE_BATCH_SIZE and len(np.concatenate(results_acc[sim.EVENT_SEPARATOR], axis=0)) > 0:
+        if len(results_acc['event_id']) >= sim.WRITE_BATCH_SIZE and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
             last_time = save_results(event_times, is_first_event=last_time==0, results=results_acc)
             results_acc = defaultdict(list)
 
         logger.take_snapshot([len(logger.log)])
 
     # Always save results after last iteration
-    if len(results_acc[sim.EVENT_SEPARATOR]) >0 and len(np.concatenate(results_acc[sim.EVENT_SEPARATOR], axis=0)) > 0:
+    if len(results_acc['event_id']) >0 and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
         save_results(event_times, is_first_event=last_time==0, results=results_acc)
 
     logger.take_snapshot([len(logger.log)])

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -376,7 +376,7 @@ def run_simulation(input_filename,
             for field in dtype[1:]:
                 new_vertices[field[0]] = vertices[field[0]]
             vertices = new_vertices
-        uniq_ev, counts = np.unique(vertices['event_id'], return_counts=True)
+        uniq_ev, counts = np.unique(vertices[sim.EVENT_SEPARATOR], return_counts=True)
         vertices['t_event'] = np.repeat(event_times.get(),counts) 
 
     if sim.IS_SPILL_SIM:
@@ -453,7 +453,7 @@ def run_simulation(input_filename,
         for key in list(results.keys()):
             results[key] = np.concatenate([cp.asnumpy(arr) for arr in results[key]], axis=0)
 
-        uniq_events = cp.asnumpy(np.unique(results['event_id']))
+        uniq_events = cp.asnumpy(np.unique(results[sim.EVENT_SEPARATOR]))
         uniq_event_times = cp.asnumpy(event_times[uniq_events % sim.MAX_EVENTS_PER_FILE])
         if light.LIGHT_SIMULATED:
             # prep arrays for embedded triggers in charge data stream
@@ -468,7 +468,7 @@ def run_simulation(input_filename,
             light_trigger_times = np.zeros_like(uniq_event_times)
             light_trigger_event_ids = uniq_events
 
-        fee.export_to_hdf5(results['event_id'],
+        fee.export_to_hdf5(results[sim.EVENT_SEPARATOR],
                            results['adc_tot'],
                            results['adc_tot_ticks'],
                            results['unique_pix'],
@@ -650,7 +650,7 @@ def run_simulation(input_filename,
             adc_event_ids = np.full(adc_list.shape, unique_eventIDs[0]) # FIXME: only works if looping on a single event
             RangePop()
 
-            results_acc['event_id'].append(adc_event_ids)
+            results_acc[sim.EVENT_SEPARATOR].append(adc_event_ids)
             results_acc['adc_tot'].append(adc_list)
             results_acc['adc_tot_ticks'].append(adc_ticks_list)
             results_acc['unique_pix'].append(unique_pix)
@@ -733,14 +733,14 @@ def run_simulation(input_filename,
                 results_acc['light_waveforms_true_track_id'].append(light_digit_signal_true_track_id)
                 results_acc['light_waveforms_true_photons'].append(light_digit_signal_true_photons)
         
-        if len(results_acc['event_id']) >= sim.WRITE_BATCH_SIZE and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
+        if len(results_acc[sim.EVENT_SEPARATOR]) >= sim.WRITE_BATCH_SIZE and len(np.concatenate(results_acc[sim.EVENT_SEPARATOR], axis=0)) > 0:
             last_time = save_results(event_times, is_first_event=last_time==0, results=results_acc)
             results_acc = defaultdict(list)
 
         logger.take_snapshot([len(logger.log)])
 
     # Always save results after last iteration
-    if len(results_acc['event_id']) >0 and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
+    if len(results_acc[sim.EVENT_SEPARATOR]) >0 and len(np.concatenate(results_acc[sim.EVENT_SEPARATOR], axis=0)) > 0:
         save_results(event_times, is_first_event=last_time==0, results=results_acc)
 
     logger.take_snapshot([len(logger.log)])

--- a/larndsim/consts/sim.py
+++ b/larndsim/consts/sim.py
@@ -12,12 +12,12 @@ from .units import mm, cm, V, kV
 BATCH_SIZE = 10000    # units = track segments
 EVENT_BATCH_SIZE = 1  # units = N tpcs
 WRITE_BATCH_SIZE = 1  # units = N batches
-EVENT_SEPARATOR = 'vertexID'  # 'spillID' or 'vertexID'
+EVENT_SEPARATOR = 'event_id'  # 'spillID' or 'vertexID'
 
 IS_SPILL_SIM = True
 IF_ACTIVE_VOLUME_CHECK = False
 SPILL_PERIOD = 1.2e6  # units = microseconds
-TRACKS_DSET_NAME = 'tracks'
+TRACKS_DSET_NAME = 'segments'
 
 # We mod event IDs by MAX_EVENTS_PER_FILE to get zero-based IDs for indexing
 # purposes; see comments in simulate_pixels.py

--- a/larndsim/simulation_properties/singles_sim.yaml
+++ b/larndsim/simulation_properties/singles_sim.yaml
@@ -4,5 +4,6 @@ write_batch_size: 1000       # batches
 is_spill_sim: 0              # boolean
 if_active_volume_check: 0    # boolean
 spill_period: 1.2e6          # microseconds
-event_separator: 'eventID'   # 'eventID'
+event_separator: 'event_id'   # 'eventID'
+tracks_dset_name: 'segments' # or 'segments'
 max_events_per_file: 1000


### PR DESCRIPTION
I noticed some inconsistencies in the naming/labeling of some variables like `eventID`. Some of these inconsistencies have led to an error or two when running a fresh clone of the develop branch. The changes I have made are small and are the following:

1. In `dumpTree.py`, changed some parameter names, like `eventID`, `vertexID`, `parentID`, etc, to match the new definitions described in 2x2_sim (https://github.com/DUNE/2x2_sim/wiki/File-data-definitions). So `eventID`->`event_id`, `vertexID`->`vertex_id`, etc.

2. I saw that despite defining the `event_separator` in `simulation_properties`, `simulate_pixels.py` uses a hardcoded `event_id`. I just changed those instances to `sim.EVENT_SEPARATOR`, like elsewhere in the code

3. In `simulation_properties/singles_sim.yaml`, add missing `tracks_dset_name` and change `event_separator` to `event_id`, like in `simulation_properties/2x2_NuMI_sim.yaml`

4. In `consts/sim.py`, change default `EVENT_SEPARATOR` and `TRACKS_DSET_NAME` to `event_id` and `segments` respectively

`dumpTree.py` and `simulate_pixels.py` run without errors on a miniRun3 spill file with these changes.