### PR TITLE
Check YAML tpc offsets against GDML tpc offsets

### DIFF
--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -143,11 +143,12 @@ def printSegmentContainer(depth, containerName, hitSegments):
     for hitSegment in hitSegments: printHitSegment(depth, hitSegment)
 
 # Prep HDF5 file for writing
-def initHDF5File(output_file):
+def initHDF5File(output_file, module_offsets):
     with h5py.File(output_file, 'w') as f:
         f.create_dataset('trajectories', (0,), dtype=trajectories_dtype, maxshape=(None,))
         f.create_dataset('segments', (0,), dtype=segments_dtype, maxshape=(None,))
         f.create_dataset('vertices', (0,), dtype=vertices_dtype, maxshape=(None,))
+        f['segments'].attrs['module_offsets'] = module_offsets
 
 # Resize HDF5 file and save output arrays
 def updateHDF5File(output_file, trajectories, segments, vertices):
@@ -206,13 +207,13 @@ def dump(input_file, output_file):
             be written
     """
 
-    # Prep output file
-    initHDF5File(output_file)
-    
     # Get module offsets for larnd-sim to use later
     module_offsets_GDML = get_module_offsets(input_file)
     if len(module_offsets_GDML) == 0 and module_offsets_GDML is not None:
         print(f'Active volume not found in TGeoManager of input file, check volume name in cpp file.')
+    
+    # Prep output file
+    initHDF5File(output_file, np.array(module_offsets_GDML))
     
     segment_id = 0
 

--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -149,7 +149,9 @@ def initHDF5File(output_file, module_offsets=None):
         f.create_dataset('segments', (0,), dtype=segments_dtype, maxshape=(None,))
         f.create_dataset('vertices', (0,), dtype=vertices_dtype, maxshape=(None,))
         if module_offsets is not None:
-            f['segments'].attrs['module_offsets'] = np.array(module_offsets)
+            f['segments'].attrs['module_offsets'] = np.array(module_offsets)/10
+        else:
+            f['segments'].attrs['module_offsets'] = np.zeros((0,))
 
 # Resize HDF5 file and save output arrays
 def updateHDF5File(output_file, trajectories, segments, vertices):
@@ -189,12 +191,7 @@ def get_module_offsets(input_file):
     elif foundTGeoManager:
         # Convert the result to a Python list
         global_origins_list = [[global_origins.at(i).at(j) for j in range(global_origins.at(i).size())] for i in range(global_origins.size())]
-        #Print the global origins
-        #for i, global_origin in enumerate(global_origins_list):
-        #    print(f'Global origin of volume {i}: {global_origin}')
         return global_origins_list
-    else:
-        return []
 
 # Read a file and dump it.
 def dump(input_file, output_file):

--- a/cli/dumpTree.py
+++ b/cli/dumpTree.py
@@ -143,12 +143,13 @@ def printSegmentContainer(depth, containerName, hitSegments):
     for hitSegment in hitSegments: printHitSegment(depth, hitSegment)
 
 # Prep HDF5 file for writing
-def initHDF5File(output_file, module_offsets):
+def initHDF5File(output_file, module_offsets=None):
     with h5py.File(output_file, 'w') as f:
         f.create_dataset('trajectories', (0,), dtype=trajectories_dtype, maxshape=(None,))
         f.create_dataset('segments', (0,), dtype=segments_dtype, maxshape=(None,))
         f.create_dataset('vertices', (0,), dtype=vertices_dtype, maxshape=(None,))
-        f['segments'].attrs['module_offsets'] = module_offsets
+        if module_offsets is not None:
+            f['segments'].attrs['module_offsets'] = np.array(module_offsets)
 
 # Resize HDF5 file and save output arrays
 def updateHDF5File(output_file, trajectories, segments, vertices):
@@ -209,11 +210,11 @@ def dump(input_file, output_file):
 
     # Get module offsets for larnd-sim to use later
     module_offsets_GDML = get_module_offsets(input_file)
-    if len(module_offsets_GDML) == 0 and module_offsets_GDML is not None:
+    if module_offsets_GDML is not None and len(module_offsets_GDML) == 0:
         print(f'Active volume not found in TGeoManager of input file, check volume name in cpp file.')
     
     # Prep output file
-    initHDF5File(output_file, np.array(module_offsets_GDML))
+    initHDF5File(output_file, module_offsets_GDML)
     
     segment_id = 0
 

--- a/cli/get_module_offsets.cpp
+++ b/cli/get_module_offsets.cpp
@@ -1,0 +1,78 @@
+#include <TGeoManager.h>
+#include <TFile.h>
+#include <iostream>
+#include <memory>
+#include <vector>
+#include <string>
+#include <functional>
+
+std::pair<bool, std::vector<std::vector<double>>> get_module_offsets(const char* fileName) {
+    // Open the ROOT file
+    TFile file(fileName);
+
+    // Check if the file has a TGeoManager
+    if (!file.Get("EDepSimGeometry")) {
+        // If the file does not have a TGeoManager, return false
+        return {false, {}};
+    }
+
+    // Import the TGeoManager
+    TGeoManager* geoManager = TGeoManager::Import(fileName);
+
+    // Get the top volume
+    TGeoNode* topVolume = geoManager->GetTopNode();
+
+    // The global origins of the target volumes
+    std::vector<std::vector<double>> globalOrigins;
+
+    // Define a recursive function to traverse the geometry tree
+    std::function<void(TGeoNode*, std::unique_ptr<TGeoHMatrix>)> traverse;
+
+    traverse = [&traverse, &globalOrigins](TGeoNode* node, std::unique_ptr<TGeoHMatrix> globalMatrix) {
+        if (globalMatrix == nullptr) {
+            globalMatrix = std::make_unique<TGeoHMatrix>();  // identity matrix
+        } else {
+            // Combine the current node's transformation with the accumulated transformation
+            TGeoHMatrix localMatrix = *globalMatrix;
+            localMatrix.Multiply(node->GetMatrix());
+            globalMatrix = std::make_unique<TGeoHMatrix>(localMatrix);
+        }
+
+        // The volume names we're looking for
+        std::vector<std::string> targetVolumes = {"volTPCActive_PV"};
+        //for (int i = 0; i < 5; ++i) {
+        //    for (int j = 0; j < 7; ++j) {
+        //        targetVolumes.push_back("volLArActiveModWall" + std::to_string(i) + std::to_string(j) + "_PV");
+        //    }
+        //}
+
+        // Check if the node's volume is one of the volumes we're looking for
+        for (const auto& volumeName : targetVolumes) {
+            if (volumeName == node->GetVolume()->GetName()) {
+                // The local origin coordinates
+                Double_t localOrigin[3] = {0., 0., 0.};
+                // The array to store the global origin coordinates
+                Double_t globalOrigin[3];
+                // Convert local coordinates to global coordinates
+                globalMatrix->LocalToMaster(localOrigin, globalOrigin);
+                // Add the global origin to the list
+                globalOrigins.push_back({globalOrigin[0], globalOrigin[1], globalOrigin[2]});
+            }
+        }
+
+        // Recursively traverse the node's daughters
+        for (int i = 0; i < node->GetNdaughters(); ++i) {
+            TGeoNode* daughter = node->GetDaughter(i);
+            traverse(daughter, std::make_unique<TGeoHMatrix>(*globalMatrix));
+        }
+    };
+
+    // Start the traversal from the top volume
+    traverse(topVolume, nullptr);
+
+    // Close the file when you're done
+    file.Close();
+
+    // Return true and the global origins
+    return {true, globalOrigins};
+}

--- a/cli/get_module_offsets.cpp
+++ b/cli/get_module_offsets.cpp
@@ -1,4 +1,7 @@
-// This is a script to get the TGeoManager from the edep-sim ROOT file and extract the module (TPC) offsets for use in larnd-sim. To get the module offsets, we need to recursively traverse the geometry tree until we encounter the LAr volumes, taking account of the translations and rotations along the way.
+// This is a script to get the TGeoManager from the edep-sim ROOT file and 
+// extract the module offsets for use in larnd-sim. To get the module offsets, 
+// we need to recursively traverse the geometry tree until we encounter the LAr volumes, 
+// taking account of the translations and rotations along the way.
 
 #include <TGeoManager.h>
 #include <TFile.h>
@@ -40,7 +43,7 @@ std::pair<bool, std::vector<std::vector<double>>> get_module_offsets(const char*
         }
 
         // The volume names we're looking for. Note that you may need to add
-        // new names that correspond to new geometries (e.g. FSD, ndlar)
+        // new names that correspond to new geometries (e.g. updated 2x2, FSD, ndlar)
         std::vector<std::string> targetVolumes = {"volTPCActive_PV"}; // single module or SingleCube
         // for 2x2, get the module wall volumes for the offsets
         for (int i = 0; i < 2; ++i) { 

--- a/larndsim/consts/__init__.py
+++ b/larndsim/consts/__init__.py
@@ -3,7 +3,7 @@ Set global variables with detector and physics properties
 """
 from . import detector, light, sim
 
-def load_properties(detprop_file, pixel_file, sim_file):
+def load_properties(detprop_file, pixel_file, sim_file, module_offsets_GDML=None):
     """
     The function loads the detector properties,
     the pixel geometry, and the simulation YAML files
@@ -13,7 +13,8 @@ def load_properties(detprop_file, pixel_file, sim_file):
         detprop_file (str): detector properties YAML filename
         pixel_file (str): pixel layout YAML filename
         sim_file (str): simulation properties YAML filename
+        module_offsets_GDML (:obj:`numpy.ndarray`): module offsets from the GDML geometry
     """
-    detector.set_detector_properties(detprop_file, pixel_file)
+    detector.set_detector_properties(detprop_file, pixel_file, module_offsets_GDML)
     light.set_light_properties(detprop_file)
     sim.set_simulation_properties(sim_file)


### PR DESCRIPTION
This PR contains a method to check the TPC offsets (from the detector properties YAML files) against the TPC offsets in the GDML used to make the edep-sim input file. The steps are the following:

1. When `dumpTree.py` is run, a ROOT cpp macro is called (`get_module_offsets.cpp`). This script opens the TGeoManager in the edep-sim ROOT file (if such a TGeoManager exists) and recursively traverses the nodes from the top node in the geometry until it finds the nodes of interest (i.e. of the active LAr). It has to do this to get the global coordinates (the tpc offsets) of the nodes of interest by accounting for translations and rotations along the way. Once the tpc offsets are found, they are returned to `dumpTree.py` where they are saved as an attribute in the `segments` dataset.

2. When running `simulate_pixels.py`, the code retrieves the tpc offsets from the attribute saved in the `segments` dataset and passes them to `detector.py`. There it checks the tpc offsets of the YAML against the GDML offsets. If they do not match, a warning is printed along with the YAML and GDML tpc offsets. Currently, the simulation will still use the YAML offsets even if there is a mismatch, but we can change this if we want. Nevertheless, the warning should be sufficient to alert the user of the mismatch.
 
The code should handle when either 1) no TGeoManager was found in the ROOT file (prints a warning) and 2) it could not find the nodes corresponding to the active LAr. For future geometries, we may (and will) need to add new names for the nodes of interest.
https://github.com/sam-fogarty/larnd-sim/blob/3b83c5948ce5215b23457e12ee264cfe96987f93/cli/get_module_offsets.cpp#L45C1-L53C10

There is one issue, but not with this implementation specifically. Given how the 2x2_sim is setup, the TGeoManager is not retained in the spill file. So we cannot take advantage of this check with 2x2 simulations currently.

Tested on:
1. MiniRun4_1E19_RHC.spill.00000.EDEPSIM_SPILLS.root: No TGeoManager in this file, and the code recognizes this and just prints a warning that no TGeoManager can be found, and that the YAML offsets will not be checked.
2. MiniRun4_1E19_RHC.rock.00000.EDEPSIM.root: Has a TGeoManager, and the code finds the GDML offsets and checks them against the YAML offsets. Currently the YAML and GDML offsets match (the GDML used is [v3](https://github.com/DUNE/2x2_sim/tree/develop/run-edep-sim/geometry/Merged2x2MINERvA_v3) I think). 
3. edep_39Ar_betas_10k.root: A module-0 simulation. Has a TGeoManager, and the YAML and GDML offsets match.

Any suggestions on how to improve this PR are welcomed.