### PR TITLE
Feature/limited light backtracking with MAX_MC_TRUTH_IDS = 3 and MC_LIGHT_THRESHOLD=1

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -713,8 +713,8 @@ def run_simulation(input_filename,
                 sorted_indices = np.zeros((n_light_det, selected_tracks.shape[0]), dtype=np.int32)
 
                 for idet in range(n_light_det):
-                    print(light_inc[:,idet]['n_photons_det'])
-                    sorted_indices[idet] = np.argsort(light_inc[:,idet]['n_photons_det'])[::-1]
+                    sorted_indices[idet] = np.argsort(light_inc[:,idet]['n_photons_det'])[::-1] # get the order in which to loop over tracks
+                    print(sorted_indices[idet])
                 ### END OF TEMPORARY FIX ###
 
                 TPB = (1,64)

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -708,13 +708,21 @@ def run_simulation(input_filename,
                 light_sample_inc_true_track_id = cp.full((n_light_det, n_light_ticks, light.MAX_MC_TRUTH_IDS), -1, dtype='i8')
                 light_sample_inc_true_photons = cp.zeros((n_light_det, n_light_ticks, light.MAX_MC_TRUTH_IDS), dtype='f8')
 
+                ### TAKE LIMITED SEGMENTS FOR LIGHT TRUTH ###
+                ### FIXME: this is a temporary fix to avoid memory issues ###
+                sorted_indices = np.zeros((n_light_det, selected_tracks.shape[0]), dtype=np.int32)
+
+                for idet in range(n_light_det):
+                    sorted_indices[idet] = np.argsort(light_inc[:,idet]['n_photons_det'])[::-1]
+                ### END OF TEMPORARY FIX ###
+
                 TPB = (1,64)
                 BPG = (max(ceil(light_sample_inc.shape[0] / TPB[0]),1),
                        max(ceil(light_sample_inc.shape[1] / TPB[1]),1))
                 light_sim.sum_light_signals[BPG, TPB](
                     selected_tracks, track_light_voxel[batch_mask][itrk:itrk+sim.BATCH_SIZE], selected_track_id,
                     light_inc, op_channel, lut, light_t_start, light_sample_inc, light_sample_inc_true_track_id,
-                    light_sample_inc_true_photons)
+                    light_sample_inc_true_photons, sorted_indices)
                 RangePop()
                 if light_sample_inc_true_track_id.shape[-1] > 0 and cp.any(light_sample_inc_true_track_id[...,-1] != -1):
                     warnings.warn(f"Maximum number of true segments ({light.MAX_MC_TRUTH_IDS}) reached in backtracking info, consider increasing MAX_MC_TRUTH_IDS (larndsim/consts/light.py)")

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -713,6 +713,7 @@ def run_simulation(input_filename,
                 sorted_indices = np.zeros((n_light_det, selected_tracks.shape[0]), dtype=np.int32)
 
                 for idet in range(n_light_det):
+                    print(light_inc[:,idet]['n_photons_det'])
                     sorted_indices[idet] = np.argsort(light_inc[:,idet]['n_photons_det'])[::-1]
                 ### END OF TEMPORARY FIX ###
 

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -714,7 +714,6 @@ def run_simulation(input_filename,
 
                 for idet in range(n_light_det):
                     sorted_indices[idet] = np.argsort(light_inc[:,idet]['n_photons_det'])[::-1] # get the order in which to loop over tracks
-                    print(sorted_indices[idet])
                 ### END OF TEMPORARY FIX ###
 
                 TPB = (1,64)

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -8,7 +8,7 @@ import os
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
 MAX_MC_TRUTH_IDS = 3 # higher is better, but file size increases
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 5 # was 0.1 pe/us lower is better, but memory usage increases
+MC_TRUTH_THRESHOLD = 0.1 # pe/us lower is better, but memory usage increases
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -6,9 +6,9 @@ import numpy as np
 import os
 
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
-MAX_MC_TRUTH_IDS = 3 # higher is better, but file size increases
+MAX_MC_TRUTH_IDS = 0 # higher is better, but file size increases
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 1 # pe/us lower is better, but memory usage increases
+MC_TRUTH_THRESHOLD = 0.1 # pe/us lower is better, but memory usage increases
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0
@@ -73,6 +73,7 @@ def set_light_properties(detprop_file):
 
     """
     global MAX_MC_TRUTH_IDS
+    global MC_TRUTH_THRESHOLD
     global N_OP_CHANNEL
     global LIGHT_SIMULATED
     global OP_CHANNEL_EFFICIENCY
@@ -107,7 +108,8 @@ def set_light_properties(detprop_file):
 
     try:
         LIGHT_SIMULATED = bool(detprop.get('light_simulated', LIGHT_SIMULATED))
-        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids', 3)
+        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids', MAX_MC_TRUTH_IDS)
+        MC_TRUTH_THRESHOLD = detprop.get('mc_truth_threshold', MC_TRUTH_THRESHOLD)
 
         N_OP_CHANNEL = detprop['n_op_channel']
         OP_CHANNEL_EFFICIENCY = np.array(detprop['op_channel_efficiency'])

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -8,7 +8,7 @@ import os
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
 MAX_MC_TRUTH_IDS = 3 #256
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 1 # 0.1 pe/us
+MC_TRUTH_THRESHOLD = 2 # 0.1 pe/us
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -6,7 +6,7 @@ import numpy as np
 import os
 
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
-MAX_MC_TRUTH_IDS = 3 # higher is better, but file size increases
+MAX_MC_TRUTH_IDS = 20 # higher is better, but file size increases
 #: Threshold for propogating truth information on a given SiPM
 MC_TRUTH_THRESHOLD = 0.1 # pe/us lower is better, but memory usage increases
 ENABLE_LUT_SMEARING = False

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -107,7 +107,7 @@ def set_light_properties(detprop_file):
 
     try:
         LIGHT_SIMULATED = bool(detprop.get('light_simulated', LIGHT_SIMULATED))
-        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids',3)
+        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids',20)
 
         N_OP_CHANNEL = detprop['n_op_channel']
         OP_CHANNEL_EFFICIENCY = np.array(detprop['op_channel_efficiency'])

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -6,9 +6,9 @@ import numpy as np
 import os
 
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
-MAX_MC_TRUTH_IDS = 3 #256
+MAX_MC_TRUTH_IDS = 3 # higher is better, but file size increases
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 2 # 0.1 pe/us
+MC_TRUTH_THRESHOLD = 5 # was 0.1 pe/us lower is better, but memory usage increases
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -6,9 +6,9 @@ import numpy as np
 import os
 
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
-MAX_MC_TRUTH_IDS = 20 # higher is better, but file size increases
+MAX_MC_TRUTH_IDS = 3 # higher is better, but file size increases
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 0.1 # pe/us lower is better, but memory usage increases
+MC_TRUTH_THRESHOLD = 1 # pe/us lower is better, but memory usage increases
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0
@@ -107,7 +107,7 @@ def set_light_properties(detprop_file):
 
     try:
         LIGHT_SIMULATED = bool(detprop.get('light_simulated', LIGHT_SIMULATED))
-        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids',20)
+        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids', 3)
 
         N_OP_CHANNEL = detprop['n_op_channel']
         OP_CHANNEL_EFFICIENCY = np.array(detprop['op_channel_efficiency'])

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -6,9 +6,9 @@ import numpy as np
 import os
 
 #: Number of true segments to track for each time tick (`MAX_MC_TRUTH_IDS=0` to disable complete truth tracking)
-MAX_MC_TRUTH_IDS = 0 #256
+MAX_MC_TRUTH_IDS = 3 #256
 #: Threshold for propogating truth information on a given SiPM
-MC_TRUTH_THRESHOLD = 0.1 # pe/us
+MC_TRUTH_THRESHOLD = 1 # 0.1 pe/us
 ENABLE_LUT_SMEARING = False
 
 N_OP_CHANNEL = 0
@@ -107,7 +107,7 @@ def set_light_properties(detprop_file):
 
     try:
         LIGHT_SIMULATED = bool(detprop.get('light_simulated', LIGHT_SIMULATED))
-        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids',0)
+        MAX_MC_TRUTH_IDS = detprop.get('max_light_truth_ids',3)
 
         N_OP_CHANNEL = detprop['n_op_channel']
         OP_CHANNEL_EFFICIENCY = np.array(detprop['op_channel_efficiency'])

--- a/larndsim/detector_properties/2x2.yaml
+++ b/larndsim/detector_properties/2x2.yaml
@@ -53,3 +53,5 @@ light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
 light_nbit: 14
+max_light_truth_ids: 3 # set to zero to disable light truth backtracking
+mc_truth_threshold: 1 # pe/us

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -341,7 +341,7 @@ def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_i
                         # apply convolution if convolution tick matches or if available truth slot
                         if light_sample_inc_true_track_id[idet,itick,jtrue] == light_sample_inc_true_track_id[idet,itick,itrue] or light_sample_inc_true_track_id[idet,itick,jtrue] == -1:
                             light_response_true_track_id[idet,itick,jtrue] = light_sample_inc_true_track_id[idet,itick,itrue]
-                            light_response_true_photons[idet,itick,jtrue] += LIGHT_GAIN[idet] * tick_weight * light_sample_inc_true_photons[idet,jtick,itrue]
+                            light_response_true_photons[idet,itick,jtrue] += tick_weight * light_sample_inc_true_photons[idet,jtick,itrue]
                             break
                 
 

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -341,7 +341,7 @@ def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_i
                         # apply convolution if convolution tick matches or if available truth slot
                         if light_sample_inc_true_track_id[idet,itick,jtrue] == light_sample_inc_true_track_id[idet,itick,itrue] or light_sample_inc_true_track_id[idet,itick,jtrue] == -1:
                             light_response_true_track_id[idet,itick,jtrue] = light_sample_inc_true_track_id[idet,itick,itrue]
-                            light_response_true_photons[idet,itick,jtrue] += tick_weight * light_sample_inc_true_photons[idet,jtick,itrue]
+                            light_response_true_photons[idet,itick,jtrue] += LIGHT_GAIN[idet] * tick_weight * light_sample_inc_true_photons[idet,jtick,itrue]
                             break
                 
 

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -56,7 +56,7 @@ def get_active_op_channel(light_incidence):
     return cp.empty((0,), dtype='i4')
     
 @cuda.jit
-def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_channel, lut, start_time, light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons):
+def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_channel, lut, start_time, light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, sorted_indices):
     """
     Sums the number of photons observed by each light detector at each time tick
 
@@ -71,6 +71,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
         light_sample_inc(array): output array, shape `(ndet, nticks)`, number of photons incident on each detector at each time tick (propogation delay only)
         light_sample_inc_true_track_id(array): output array, shape `(ndet, nticks, maxtracks)`, true track ids on each detector at each time tick (propogation delay only)
         light_sample_inc_true_photons(array): output array, shape `(ndet, nticks, maxtracks)`, number of photons incident on each detector at each time tick from each track
+        sorted_indices(array): shape `(MAX_MC_TRUTH_IDS,)`, indices of segments sorted by how much light they contribute
     """
     idet,itick = cuda.grid(2)
 
@@ -82,7 +83,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
 
             # find tracks that contribute light to this time tick
             idet_lut = op_channel[idet] % lut.shape[3]
-            for itrk in range(segments.shape[0]):
+            for itrk in sorted_indices[idet]:
                 if light_inc[itrk,op_channel[idet]]['n_photons_det'] > 0:
                     voxel = segment_voxel[itrk]
                     time_profile = lut[voxel[0],voxel[1],voxel[2],idet_lut]['time_dist']

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -71,7 +71,7 @@ def sum_light_signals(segments, segment_voxel, segment_track_id, light_inc, op_c
         light_sample_inc(array): output array, shape `(ndet, nticks)`, number of photons incident on each detector at each time tick (propogation delay only)
         light_sample_inc_true_track_id(array): output array, shape `(ndet, nticks, maxtracks)`, true track ids on each detector at each time tick (propogation delay only)
         light_sample_inc_true_photons(array): output array, shape `(ndet, nticks, maxtracks)`, number of photons incident on each detector at each time tick from each track
-        sorted_indices(array): shape `(MAX_MC_TRUTH_IDS,)`, indices of segments sorted by how much light they contribute
+        sorted_indices(array): shape `(maxtracks,)`, indices of segments sorted by how much light they contribute
     """
     idet,itick = cuda.grid(2)
 


### PR DESCRIPTION
Very limited light backtracking. Per light detector per tick true photons per segment are saved. The maximum number of segments per light detector per tick is 3. Only light signals larger than 1 pe are accepted. The segments are sorted in order of the number of photons they contribute to a light detector, so we get only the most relevant segments.
NB. these settings cause unpredictable cuda memory errors, setting MAX_MC_TRUTH_IDS=0 will disable the light truth info.