### PR TITLE
Feature/ajw minirun5 fix

### DIFF
--- a/larndsim/detector_properties/2x2.yaml
+++ b/larndsim/detector_properties/2x2.yaml
@@ -60,7 +60,7 @@ light_trig_mode: 1
 light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
-light_tick_size: 0.016 #us
+#light_tick_size: 0.016 #us
 light_nbit: 14
 max_light_truth_ids: 0 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/detector_properties/2x2.yaml
+++ b/larndsim/detector_properties/2x2.yaml
@@ -60,7 +60,6 @@ light_trig_mode: 1
 light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
-#light_tick_size: 0.016 #us
 light_nbit: 14
 max_light_truth_ids: 0 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/detector_properties/2x2.yaml
+++ b/larndsim/detector_properties/2x2.yaml
@@ -60,6 +60,7 @@ light_trig_mode: 1
 light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
+light_tick_size: 0.016 #us
 light_nbit: 14
 max_light_truth_ids: 0 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -584,7 +584,7 @@ def sim_triggers(bpg, tpb, signal, signal_op_channel_idx, signal_true_track_id, 
     pre_digit_ticks = int(ceil(light.LIGHT_TRIG_WINDOW[0]/light.LIGHT_TICK_SIZE))
     if trigger_idx.min() - pre_digit_ticks < 0:
         pad_shape = (signal.shape[0], int(pre_digit_ticks - trigger_idx.min()))
-        signal = cp.concatenate([gen_light_detector_noise(pad_shape, light_det_noise[signal_op_channel_idx]), signal], axis=-1)
+        signal = cp.concatenate([(gen_light_detector_noise(pad_shape, light_det_noise[signal_op_channel_idx]) / 2**(16-light.LIGHT_NBIT)), signal], axis=-1)
         signal_true_track_id = cp.concatenate([cp.full(pad_shape + signal_true_track_id.shape[-1:], -1, dtype=signal_true_track_id.dtype), signal_true_track_id], axis=-2)
         signal_true_photons = cp.concatenate([cp.zeros(pad_shape + signal_true_photons.shape[-1:], signal_true_photons.dtype), signal_true_photons], axis=-2)
         padded_trigger_idx += pad_shape[1]
@@ -594,7 +594,7 @@ def sim_triggers(bpg, tpb, signal, signal_op_channel_idx, signal_true_track_id, 
     if post_digit_ticks + padded_trigger_idx.max() > signal.shape[1]:
         pad_shape = (signal.shape[0], int(post_digit_ticks + padded_trigger_idx.max() - signal.shape[1]))
 
-        signal = cp.concatenate([signal, gen_light_detector_noise(pad_shape, light_det_noise[signal_op_channel_idx])], axis=-1)
+        signal = cp.concatenate([signal, (gen_light_detector_noise(pad_shape, light_det_noise[signal_op_channel_idx]) / 2**(16-light.LIGHT_NBIT))], axis=-1)
         signal_true_track_id = cp.concatenate([signal_true_track_id, cp.full(pad_shape + signal_true_track_id.shape[-1:], -1, dtype=signal_true_track_id.dtype)], axis=-2)
         signal_true_photons = cp.concatenate([signal_true_photons, cp.zeros(pad_shape + signal_true_photons.shape[-1:], dtype=signal_true_photons.dtype)], axis=-2)
 
@@ -602,7 +602,7 @@ def sim_triggers(bpg, tpb, signal, signal_op_channel_idx, signal_true_track_id, 
     if cp.any(~cp.isin(op_channel_idx, signal_op_channel_idx)):
         missing = cp.unique(op_channel_idx[~cp.isin(op_channel_idx, signal_op_channel_idx)])
         pad_shape = (missing.shape[0], signal.shape[-1])
-        signal = cp.concatenate([signal, gen_light_detector_noise(pad_shape, light_det_noise[missing])], axis=0)
+        signal = cp.concatenate([signal, (gen_light_detector_noise(pad_shape, light_det_noise[missing]) / 2**(16-light.LIGHT_NBIT))], axis=0)
         signal_op_channel_idx = cp.concatenate([signal_op_channel_idx, missing], axis=0)
         signal_true_track_id = cp.concatenate([signal_true_track_id, cp.full(pad_shape + signal_true_track_id.shape[-1:], -1, dtype=signal_true_track_id.dtype)], axis=0)
         signal_true_photons = cp.concatenate([signal_true_photons, cp.zeros(pad_shape + signal_true_photons.shape[-1:], dtype=signal_true_photons.dtype)], axis=0)


### PR DESCRIPTION
Removes double digitization of noise padding at front and back of light waveforms. 