### PR TITLE
Light backtracking reshape

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -135,7 +135,7 @@ def run_simulation(input_filename,
             store memory snapshot information
     """
     # Define a nested function to save the results
-    def save_results(event_times, is_first_batch, results, i_mod=-1, light_only=False):
+    def save_results(event_times, is_first_batch, results, i_trig, i_mod=-1, light_only=False):
         '''
         results is a dictionary with the following keys
 
@@ -214,6 +214,7 @@ def run_simulation(input_filename,
                                                     output_filename,
                                                     results['light_waveforms_true_track_id'],
                                                     results['light_waveforms_true_photons'],
+                                                    i_trig,
                                                     i_mod)
         if is_first_batch:
             is_first_batch = False
@@ -760,6 +761,7 @@ def run_simulation(input_filename,
         logger.start()
         logger.take_snapshot([0])
         i_batch = 0
+        i_trig = 0
         sync_start = event_times[0] // (fee.CLOCK_RESET_PERIOD * fee.CLOCK_CYCLE) * (fee.CLOCK_RESET_PERIOD * fee.CLOCK_CYCLE) +  (fee.CLOCK_RESET_PERIOD * fee.CLOCK_CYCLE)
         det_borders = module_borders if mod2mod_variation else detector.TPC_BORDERS
         for batch_mask in tqdm(batching.TPCBatcher(all_mod_tracks, tracks, sim.EVENT_SEPARATOR, tpc_batch_size=sim.EVENT_BATCH_SIZE, tpc_borders=det_borders),
@@ -790,7 +792,8 @@ def run_simulation(input_filename,
             if len(track_subset) == 0:
                 if light.LIGHT_SIMULATED and (light.LIGHT_TRIG_MODE == 0 or light.LIGHT_TRIG_MODE == 1):
                     null_light_results_acc['light_event_id'].append(cp.full(1, ievd)) # one event
-                    save_results(event_times, is_first_batch, null_light_results_acc, i_mod, light_only=True)
+                    save_results(event_times, is_first_batch, null_light_results_acc, i_trig, i_mod, light_only=True)
+                    i_trig += 1 # add to the trigger counter
                     del null_light_results_acc['light_event_id']
                 # Nothing to simulate for charge readout?
                 continue
@@ -832,7 +835,8 @@ def run_simulation(input_filename,
                 if not active_pixels.shape[1] or not neighboring_pixels.shape[1]:
                     if light.LIGHT_SIMULATED and (light.LIGHT_TRIG_MODE == 0 or light.LIGHT_TRIG_MODE == 1):
                         null_light_results_acc['light_event_id'].append(cp.full(1, ievd)) # one event
-                        save_results(event_times, is_first_batch, null_light_results_acc, i_mod, light_only=True)
+                        save_results(event_times, is_first_batch, null_light_results_acc, i_trig, i_mod, light_only=True)
+                        i_trig += 1 # add to the trigger counter
                         del null_light_results_acc['light_event_id']
                     continue
 
@@ -854,7 +858,8 @@ def run_simulation(input_filename,
                 if not unique_pix.shape[0]:
                     if light.LIGHT_SIMULATED and (light.LIGHT_TRIG_MODE == 0 or light.LIGHT_TRIG_MODE == 1):
                         null_light_results_acc['light_event_id'].append(cp.full(1, ievd)) # one event
-                        save_results(event_times, is_first_batch, null_light_results_acc, i_mod, light_only=True)
+                        save_results(event_times, is_first_batch, null_light_results_acc, i_trig, i_mod, light_only=True)
+                        i_trig += 1 # add to the trigger counter
                         del null_light_results_acc['light_event_id']
                     continue
 
@@ -1049,9 +1054,11 @@ def run_simulation(input_filename,
 
             if len(results_acc['event_id']) >= sim.WRITE_BATCH_SIZE:
                 if len(results_acc['event_id']) > 0 and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
-                    is_first_batch = save_results(event_times, is_first_batch, results_acc, i_mod, light_only=False)
+                    is_first_batch = save_results(event_times, is_first_batch, results_acc, i_trig, i_mod, light_only=False)
+                    i_trig += 1 # add to the trigger counter
                 elif len(results_acc['light_event_id']) > 0 and len(np.concatenate(results_acc['light_event_id'], axis=0)) > 0:
-                    is_first_batch = save_results(event_times, is_first_batch, results_acc, i_mod, light_only=True)
+                    is_first_batch = save_results(event_times, is_first_batch, results_acc, i_trig, i_mod, light_only=True)
+                    i_trig += 1 # add to the trigger counter
                 results_acc = defaultdict(list)
 
             logger.take_snapshot([len(logger.log)])
@@ -1060,9 +1067,11 @@ def run_simulation(input_filename,
         RangePush('save_results')
         # Always save results after last iteration
         if len(results_acc['event_id']) > 0 and len(np.concatenate(results_acc['event_id'], axis=0)) > 0:
-            is_first_batch = save_results(event_times, is_first_batch, results_acc, i_mod, light_only=False)
+            is_first_batch = save_results(event_times, is_first_batch, results_acc, i_trig, i_mod, light_only=False)
+            i_trig += 1 # add to the trigger counter
         elif len(results_acc['light_event_id']) > 0 and len(np.concatenate(results_acc['light_event_id'], axis=0)) > 0:
-            is_first_batch = save_results(event_times, is_first_batch, results_acc, i_mod, light_only=True)
+            is_first_batch = save_results(event_times, is_first_batch, results_acc, i_trig, i_mod, light_only=True)
+            i_trig += 1 # add to the trigger counter
         RangePop()
 
     logger.take_snapshot([len(logger.log)])

--- a/larndsim/detector_properties/2x2.yaml
+++ b/larndsim/detector_properties/2x2.yaml
@@ -61,5 +61,5 @@ light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
 light_nbit: 14
-max_light_truth_ids: 0 # set to zero to disable light truth backtracking
+max_light_truth_ids: 50 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/detector_properties/2x2_mod2mod_variation.yaml
+++ b/larndsim/detector_properties/2x2_mod2mod_variation.yaml
@@ -61,5 +61,5 @@ light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
 light_nbit: 14
-max_light_truth_ids: 0 # set to zero to disable light truth backtracking
+max_light_truth_ids: 50 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/detector_properties/2x2_non_beam.yaml
+++ b/larndsim/detector_properties/2x2_non_beam.yaml
@@ -61,5 +61,5 @@ light_window: [0, 16] # us
 light_trig_window: [1.6, 14.4] # us
 light_digit_sample_spacing: 0.016 # us
 light_nbit: 14
-max_light_truth_ids: 0 # set to zero to disable light truth backtracking
+max_light_truth_ids: 50 # set to zero to disable light truth backtracking
 mc_truth_threshold: 1 # pe/us

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -622,25 +622,25 @@ def sim_triggers(bpg, tpb, signal, signal_op_channel_idx, signal_true_track_id, 
     
     return digit_signal, digit_signal_true_track_id, digit_signal_true_photons
 
-def zero_suppress_waveform_truth(spill, waveforms_true_track_id, waveforms_true_photons):
-    event_id, det_id, track_id, photons, tick = [[] for i in range(5)]
+def zero_suppress_waveform_truth(evt_id, waveforms_true_track_id, waveforms_true_photons):
+    event_id, op_channel_id, segment_id, pe_current, tick = [[] for i in range(5)]
     indices = [index for index, x in np.ndenumerate(waveforms_true_track_id) if x!=-1]
-    truth_dtype = np.dtype([('event_id','i4'),('det_id','i4'),('track_id','i8'),('pe_current','f8'),('tick','i4')])
+    truth_dtype = np.dtype([('event_id','i4'),('op_channel_id','i4'),('segment_id','i8'),('pe_current','f8'),('tick','i4')])
     for i in range(len(indices)):
         itrig=indices[i][0]
         idet_module=indices[i][1]
         isample=indices[i][2]
         icontent=indices[i][3]
-        event_id.append(spill)
-        det_id.append(idet_module)
-        track_id.append(waveforms_true_track_id[itrig][idet_module][isample][icontent])
-        photons.append(waveforms_true_photons[itrig][idet_module][isample][icontent])
+        event_id.append(evt_id)
+        op_channel_id.append(idet_module)
+        segment_id.append(waveforms_true_track_id[itrig][idet_module][isample][icontent])
+        pe_current.append(waveforms_true_photons[itrig][idet_module][isample][icontent])
         tick.append(isample)
     truth_data = np.empty(len(indices), dtype=truth_dtype)
     truth_data['event_id'] = np.array(event_id)
-    truth_data['det_id'] = np.array(det_id)
-    truth_data['track_id'] = np.array(track_id)
-    truth_data['pe_current'] = np.array(photons)
+    truth_data['op_channel_id'] = np.array(op_channel_id)
+    truth_data['segment_id'] = np.array(segment_id)
+    truth_data['pe_current'] = np.array(pe_current)
     truth_data['tick'] = np.array(tick)
     return truth_data
 


### PR DESCRIPTION
Based on feature branch [brussell_light_backtrack](https://github.com/DUNE/larnd-sim/tree/brussell_light_backtrack).

This change stores truth information in such format, `[('trigger_id', 'i4'), ('op_channel_id','i4'), ('tick','i4'), ('event_id','i4'), ('segment_id','i8'), ('pe_current','f8')]`, where `trigger_id`, `op_channel_id` and `tick` correspond to the index of the `light_wvfm` dataset which takes the shape of (#light triggers, #light readout channels, #light samples).

It has been tested on one file, `MiniRun5_1E19_RHC.convert2h5.00666.EDEPSIM.hdf5`, with modular variation activated and deactivated. This test used configuration of setting `MAX_MC_TRUTH_IDS` to 0, 20, 50, 100, 200 and `MC_TRUTH_THRESHOLD` to 1. When `MAX_MC_TRUTH_IDS = 0`, the output file size is about 1GB. With other settings, the output file size is about 1.1GB. 

The run time with respect to the setting `MAX_MC_TRUTH_IDS` can be found in the following graph. Note that the default `larndsim/bin/lightLUT.npz` is used for this test. Using the light LUT's with finer granularity will increase the run time by a few minutes.
![run_time_vs_max_track](https://github.com/DUNE/larnd-sim/assets/25907864/48ed63c0-253a-45a4-a5ab-8d6458e105ba)

The plot below shows how many segments contribute to a light waveform per optical channel per trigger. The file size with the different settings indicate that `MAX_MC_TRUTH_IDS = 20` may be sufficient, but on the conservative side, I suggest to set it to 50. The detector property yaml files are adjust accordingly.
![max_track_ids_guide](https://github.com/DUNE/larnd-sim/assets/25907864/535a979e-608a-4c0f-a2bc-4aa2958a8b93)

In addition, I'm showing the negative sum of the truth contribution in pe and ADC/4 in trigger 0 channel 16 as an example. The amplitudes do not match. Perhaps I'm comparing the wrong quantity. It needs to be looked into further. Other than that I think this branch is ready to be merged.
![MR5_666_tirg0_opchannel16](https://github.com/DUNE/larnd-sim/assets/25907864/388d4e47-3d95-4a98-ade4-6a2fde1c7f79)


