### PR TITLE
removes double swap of truth coordinates before writing to file

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1106,17 +1106,15 @@ def run_simulation(input_filename,
     if light.LIGHT_SIMULATED and mod2mod_variation:
         light_sim.merge_module_light_wvfm_same_trigger(output_filename)
 
-    # We previously called swap_coordinates(tracks), but we want to write
-    # all truth info in the edep-sim convention (z = beam coordinate). So
-    # temporarily undo the swap. It's easier than reorganizing the code!
-    swap_coordinates(tracks)
-
     # prep output file with truth datasets
     with h5py.File(output_filename, 'a') as output_file:
         # Store all tracks in the gdml module volume, could have small differences because of the active volume check
         output_file.create_dataset(sim.TRACKS_DSET_NAME, data=all_mod_tracks)
         # To distinguish from the "old" files that had z=drift in 'tracks':
         output_file[sim.TRACKS_DSET_NAME].attrs['zbeam'] = True
+        # We previously called swap_coordinates(tracks), but we want to write
+        # all truth info in the edep-sim convention (z = beam coordinate). So
+        # temporarily undo the swap. It's easier than reorganizing the code!
         swap_coordinates(tracks)
 
         if light.LIGHT_SIMULATED:


### PR DESCRIPTION
larnd-sim uses a different internal coordinate system than edep-sim. 

Below shows the previous results for truth information (red) and reconstructed hit location (blue). Beam is supposed to be ~ in the z-direction, which suggested that the truth information was not being swapped properly.

![image](https://github.com/DUNE/larnd-sim/assets/18149958/be56503c-5e59-41ce-868b-c87418bc552f)