### PR TITLE
move the swap coordinate before the data writing

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1108,14 +1108,16 @@ def run_simulation(input_filename,
 
     # prep output file with truth datasets
     with h5py.File(output_filename, 'a') as output_file:
-        # Store all tracks in the gdml module volume, could have small differences because of the active volume check
-        output_file.create_dataset(sim.TRACKS_DSET_NAME, data=all_mod_tracks)
-        # To distinguish from the "old" files that had z=drift in 'tracks':
-        output_file[sim.TRACKS_DSET_NAME].attrs['zbeam'] = True
         # We previously called swap_coordinates(tracks), but we want to write
         # all truth info in the edep-sim convention (z = beam coordinate). So
         # temporarily undo the swap. It's easier than reorganizing the code!
-        swap_coordinates(tracks)
+        swap_coordinates(all_mod_tracks)
+
+        # Store all tracks in the gdml module volume, could have small differences because of the active volume check
+        output_file.create_dataset(sim.TRACKS_DSET_NAME, data=all_mod_tracks)
+
+        # To distinguish from the "old" files that had z=drift in 'tracks':
+        output_file[sim.TRACKS_DSET_NAME].attrs['zbeam'] = True
 
         if light.LIGHT_SIMULATED:
             # It seems unnecessary to store (all tracks, all channels) given the modules are light tight


### PR DESCRIPTION
Before:
<img width="601" alt="Screenshot 2024-02-16 at 6 46 29 PM" src="https://github.com/DUNE/larnd-sim/assets/25907864/a123e3c3-5f60-4c95-8d41-fbbe5642c02c">
After with modular variation:
<img width="578" alt="Screenshot 2024-02-16 at 6 41 36 PM" src="https://github.com/DUNE/larnd-sim/assets/25907864/83946107-ba89-4d30-9bdb-c5b0efb999ab">
After without modular variation:
<img width="577" alt="Screenshot 2024-02-16 at 6 40 19 PM" src="https://github.com/DUNE/larnd-sim/assets/25907864/feb9ea37-c027-4404-b678-a050908a224d">
Maybe we should revisit the active volume check...