### PR TITLE
temp fix for light backtracking with the threshold triggering

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -207,6 +207,7 @@ def run_simulation(input_filename,
                                          uniq_event_times,
                                          results['light_waveforms_true_track_id'],
                                          results['light_waveforms_true_photons'],
+                                         i_trig,
                                          i_mod)
             elif light.LIGHT_TRIG_MODE == 1:
                 light_sim.export_light_wvfm_to_hdf5(results['light_event_id'],

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -755,7 +755,7 @@ def export_light_trig_to_hdf5(event_id, start_times, trigger_idx, op_channel_idx
             f['light_trig'].resize(f['light_trig'].shape[0] + trigger_idx.shape[0], axis=0)
             f['light_trig'][-trigger_idx.shape[0]:] = trig_data
 
-def export_to_hdf5(event_id, start_times, trigger_idx, op_channel_idx, waveforms, output_filename, event_times, waveforms_true_track_id, waveforms_true_photons, i_mod):
+def export_to_hdf5(event_id, start_times, trigger_idx, op_channel_idx, waveforms, output_filename, event_times, waveforms_true_track_id, waveforms_true_photons, i_trig, i_mod):
     """
     Saves waveforms to output file
 
@@ -772,7 +772,7 @@ def export_to_hdf5(event_id, start_times, trigger_idx, op_channel_idx, waveforms
 
     """
     export_light_trig_to_hdf5(event_id, start_times, trigger_idx, op_channel_idx, output_filename, event_times)
-    export_light_wvfm_to_hdf5(event_id, waveforms, output_filename, waveforms_true_track_id, waveforms_true_photons, i_mod)
+    export_light_wvfm_to_hdf5(event_id, waveforms, output_filename, waveforms_true_track_id, waveforms_true_photons, i_trig, i_mod)
 
 def merge_module_light_wvfm_same_trigger(output_filename):
     """


### PR DESCRIPTION
This is a band-aid for the bug Brooke pointed out in [this Issue](https://github.com/DUNE/larnd-sim/issues/205#issuecomment-1955702909). However, given the current status with simulating with light threshold triggering. We are unable to test it fully until simulation with the `LIGHT_TRIG_MODE=0` is fixed.