### PR TITLE
Light backtracking segments fix

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -973,7 +973,7 @@ def run_simulation(input_filename,
                 if light.LIGHT_SIMULATED:
                     RangePush("sum_light_signals")
                     light_inc = light_sim_dat[batch_mask][itrk:itrk+sim.BATCH_SIZE]
-                    selected_track_id = track_ids[batch_mask][itrk:itrk+sim.BATCH_SIZE]
+                    selected_track_id = np.ascontiguousarray(selected_tracks["segment_id"])
                     n_light_ticks, light_t_start = light_sim.get_nticks(light_inc)
                     n_light_ticks = min(n_light_ticks,int(5E4))
                     # at least the optical channels from a whole module are activated together

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -972,7 +972,7 @@ def run_simulation(input_filename,
                 if light.LIGHT_SIMULATED:
                     RangePush("sum_light_signals")
                     light_inc = light_sim_dat[batch_mask][itrk:itrk+sim.BATCH_SIZE]
-                    selected_track_id = np.ascontiguousarray(selected_tracks["segment_id"])
+                    selected_track_id = cp.array(selected_tracks["segment_id"])
                     n_light_ticks, light_t_start = light_sim.get_nticks(light_inc)
                     n_light_ticks = min(n_light_ticks,int(5E4))
                     # at least the optical channels from a whole module are activated together

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -972,7 +972,7 @@ def run_simulation(input_filename,
                 if light.LIGHT_SIMULATED:
                     RangePush("sum_light_signals")
                     light_inc = light_sim_dat[batch_mask][itrk:itrk+sim.BATCH_SIZE]
-                    selected_track_id = cp.array(selected_tracks["segment_id"])
+                    selected_track_id = segment_ids_arr[batch_mask][itrk:itrk+sim.BATCH_SIZE]#cp.array(selected_tracks["segment_id"])
                     n_light_ticks, light_t_start = light_sim.get_nticks(light_inc)
                     n_light_ticks = min(n_light_ticks,int(5E4))
                     # at least the optical channels from a whole module are activated together

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -761,7 +761,6 @@ def run_simulation(input_filename,
         logger.start()
         logger.take_snapshot()
 
-        track_ids = cp.asarray(np.arange(segment_ids.shape[0], dtype=int))
         segment_ids_arr = cp.asarray(segment_ids)
         # We divide the sample in portions that can be processed by the GPU
         is_first_batch = True


### PR DESCRIPTION
Use segment_id field of selected_tracks instead of track_ids to fix issue with light backtracking segments appearing in multiple events. I removed the line defining track_ids since they are no longer used anywhere and their definition is misleading.
![unique_evid_per_seg_heatmap](https://github.com/DUNE/larnd-sim/assets/24715617/2dadecf6-3648-48a6-b65d-40d5f288a9b4)
![unique_evid_per_seg_count](https://github.com/DUNE/larnd-sim/assets/24715617/7ac88b06-980b-4d9a-beeb-5205c6fd51f8)
[larndsim validation](https://github.com/DUNE/larnd-sim/files/15204230/final_test_validations.pdf)
