### PR TITLE
Update paths to light LUTs to fix missing channels bug

### DIFF
--- a/larndsim/config/config.yaml
+++ b/larndsim/config/config.yaml
@@ -46,7 +46,7 @@ module0:
     # Path to light LUT at NERSC
     # Web portal: https://portal.nersc.gov/project/dune/data/2x2/simulation/larndsim_data/light_LUT/
     # Alternatively low granularity Mod0 based light LUT in larndsim, lightLUT.npz
-    LIGHT_LUT:       [/global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0.npz, /global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123.npz] 
+    LIGHT_LUT:       [/global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024.npz, /global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024.npz] 
     LIGHT_LUT_ID:    [0, 1, 1, 1]
     MOD2MOD_VARIATION: True
 


### PR DESCRIPTION
@liviocali generated new npz LUT files with the right number of optical channels, addressing the issue of missing channels described in #223. I did a run with a single file and passed it through [larndsim_validation.py](https://github.com/DUNE/2x2_sim/blob/develop/run-validation/larndsim_validation.py#L303). The output is [here](https://github.com/DUNE/larnd-sim/files/15226629/MiniRun5_1E19_RHC.larnd.00123.20240506T202108Z.LARNDSIM_validations.pdf), and below is the plot of the light signals across the channels of the 2x2, which look much better in comparison to the [MR5 beta1 validation plots](https://portal.nersc.gov/project/dune/data/2x2/simulation/productions/MiniRun5_1E19_RHC/MiniRun5_1E19_RHC.plots.beta1/PLOTS/LARNDSIM/0000000/MiniRun5_1E19_RHC.larnd.0000012.LARNDSIM_validations.pdf):
![image](https://github.com/DUNE/larnd-sim/assets/44169114/4cabdba0-3492-4365-ab32-29abb91ad0ec)


@liviocali mentioned that these LUT files also feature a change in the object types, from `[('vis','f4'), ('t0','f4'),('time_dist','f4',(int(nbins_time),))]`  to `[('vis','f4'), ('t0','f2'),('time_dist','u2',(int(nbins_time),))]`, in order to reduce the memory usage when loading the arrays.

A quick check on the NERSC Jupyter platform shows that the memory used when loading the array from the old LUT file is ~12GB, whereas with the new version of the file it is ~2.5 GB. The change of the object types, along with the elimination of the null entries in the old file which reduces the array shape from `(64, 128, 32, 120)` to `(64, 128, 32, 48)`, seem to help with the memory usage.