### PR TITLE
Feature restore association count to store

### DIFF
--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -21,6 +21,7 @@ from .pixels_from_track import id2pixel
 
 from .consts.units import mV, e
 from .consts import units
+from .detsim import MAX_TRACKS_PER_PIXEL
 
 #: Number of back-tracked segments to be recorded
 ASSOCIATION_COUNT_TO_STORE = 10
@@ -323,8 +324,8 @@ def export_to_hdf5(event_id_list,
                     packets.append(TimestampPacket(timestamp=np.floor(event_start_time_list[0] * CLOCK_CYCLE * units.mus/units.s)) ) # s
                     packets[-1].chip_key = Key(io_group,0,0)
                     packets_mc_evt.append(np.array([-1]))
-                    packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
-                    packets_frac.append(np.array([0] * current_fractions.shape[2]))
+                    packets_mc_trk.append(np.array([-1] * MAX_TRACKS_PER_PIXEL))
+                    packets_frac.append(np.array([0] * MAX_TRACKS_PER_PIXEL))
                 packets_mc_evt.append([event])
                 packets_mc_trk.append(track_ids[itick])
                 packets_frac.append(current_fractions[itick][iadc])

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -323,8 +323,8 @@ def export_to_hdf5(event_id_list,
                     packets.append(TimestampPacket(timestamp=np.floor(event_start_time_list[0] * CLOCK_CYCLE * units.mus/units.s)) ) # s
                     packets[-1].chip_key = Key(io_group,0,0)
                     packets_mc_evt.append([-1])
-                    packets_mc_trk.append([-1] * (ASSOCIATION_COUNT_TO_STORE * 2))
-                    packets_frac.append([0] * (ASSOCIATION_COUNT_TO_STORE*2))
+                    packets_mc_trk.append([-1] * track_ids.shape[1])
+                    packets_frac.append([0] * current_fractions.shape[2])
                 packets_mc_evt.append([event])
                 packets_mc_trk.append(track_ids[itick])
                 packets_frac.append(current_fractions[itick][iadc])

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -405,9 +405,9 @@ def export_sync_to_hdf5(filename, sync_times, i_mod=-1):
             sync_tick = sync_tick // CLOCK_RESET_PERIOD * CLOCK_RESET_PERIOD
         for io_group in io_groups:
             packets.append(SyncPacket(sync_type=b'S', timestamp=sync_tick, io_group=io_group))
-            packets_mc_evt.append([-1])
-            packets_mc_trk.append([-1] * ASSOCIATION_COUNT_TO_STORE)
-            packets_frac.append([0] * ASSOCIATION_COUNT_TO_STORE)
+            packets_mc_evt.append(np.array([-1]))
+            packets_mc_trk.append(np.array([-1] * ASSOCIATION_COUNT_TO_STORE))
+            packets_frac.append(np.array([0] * ASSOCIATION_COUNT_TO_STORE))
 
     if packets:
         packet_list = PacketCollection(packets, read_id=0, message='')
@@ -459,15 +459,15 @@ def export_timestamp_trigger_to_hdf5(filename, event_start_times, i_mod=-1):
         # timestamp packets
         packets.append(TimestampPacket(timestamp=evt_time*units.mus/units.s)) # s
         packets[-1].chip_key = Key(io_group,0,0)
-        packets_mc_evt.append([-1])
-        packets_mc_trk.append([-1] * ASSOCIATION_COUNT_TO_STORE)
-        packets_frac.append([0] * ASSOCIATION_COUNT_TO_STORE)
+        packets_mc_evt.append(np.array([-1]))
+        packets_mc_trk.append(np.array([-1] * ASSOCIATION_COUNT_TO_STORE))
+        packets_frac.append(np.array([0] * ASSOCIATION_COUNT_TO_STORE))
 
         # trigger packets
         packets.append(TriggerPacket(io_group=io_group, trigger_type=b'\x02', timestamp=t_trig)) # tick
-        packets_mc_evt.append([-1])
-        packets_mc_trk.append([-1] * ASSOCIATION_COUNT_TO_STORE)
-        packets_frac.append([0] * ASSOCIATION_COUNT_TO_STORE)
+        packets_mc_evt.append(np.array([-1]))
+        packets_mc_trk.append(np.array([-1] * ASSOCIATION_COUNT_TO_STORE))
+        packets_frac.append(np.array([0] * ASSOCIATION_COUNT_TO_STORE))
 
     if packets:
         packet_list = PacketCollection(packets, read_id=0, message='')

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -250,14 +250,14 @@ def export_to_hdf5(event_id_list,
                         for io_group in io_groups:
                             packets.append(TimestampPacket(timestamp=event_start_times[unique_events_inv[itick]] * units.mus / units.s))
                             packets[-1].chip_key = Key(io_group,0,0)
-                            packets_mc_evt.append([-1])
-                            packets_mc_trk.append([-1] * track_ids.shape[1])
-                            packets_frac.append([0] * current_fractions.shape[2])
+                            packets_mc_evt.append(np.array([-1]))
+                            packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
+                            packets_frac.append(np.array([0] * current_fractions.shape[2]))
 
                             packets.append(SyncPacket(sync_type=b'S', timestamp=time_tick , io_group=io_group))
-                            packets_mc_evt.append([-1])
-                            packets_mc_trk.append([-1] * track_ids.shape[1])
-                            packets_frac.append([0] * current_fractions.shape[2])
+                            packets_mc_evt.append(np.array([-1]))
+                            packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
+                            packets_frac.append(np.array([0] * current_fractions.shape[2]))
 
                         trig_mask = light_trigger_event_id == event
                         if any(trig_mask):
@@ -266,17 +266,17 @@ def export_to_hdf5(event_id_list,
                                 if light.LIGHT_TRIG_MODE == 0:
                                     for io_group in detector.MODULE_TO_IO_GROUPS[int(module_trig)]:
                                         packets.append(TriggerPacket(io_group=io_group, trigger_type=b'\x02', timestamp=t_trig))
-                                        packets_mc_evt.append([-1])
-                                        packets_mc_trk.append([-1] * track_ids.shape[1])
-                                        packets_frac.append([0] * current_fractions.shape[2])
+                                        packets_mc_evt.append(np.array([-1]))
+                                        packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
+                                        packets_frac.append(np.array([0] * current_fractions.shape[2]))
                                 # redundant here
                                 elif light.LIGHT_TRIG_MODE == 1:
                                     if module_trig == 1 or module_trig == 0: #1, beam trigger; 2, threshold trigger
                                         io_group = get_trig_io()
                                     packets.append(TriggerPacket(io_group=io_group, trigger_type=b'\x02', timestamp=t_trig))
-                                    packets_mc_evt.append([-1])
-                                    packets_mc_trk.append([-1] * track_ids.shape[1])
-                                    packets_frac.append([0] * current_fractions.shape[2])
+                                    packets_mc_evt.append(np.array([-1]))
+                                    packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
+                                    packets_frac.append(np.array([0] * current_fractions.shape[2]))
                         last_event = event
 
                 p = Packet_v2()
@@ -322,9 +322,9 @@ def export_to_hdf5(event_id_list,
                     last_time_tick = time_tick
                     packets.append(TimestampPacket(timestamp=np.floor(event_start_time_list[0] * CLOCK_CYCLE * units.mus/units.s)) ) # s
                     packets[-1].chip_key = Key(io_group,0,0)
-                    packets_mc_evt.append([-1])
-                    packets_mc_trk.append([-1] * track_ids.shape[1])
-                    packets_frac.append([0] * current_fractions.shape[2])
+                    packets_mc_evt.append(np.array([-1]))
+                    packets_mc_trk.append(np.array([-1] * track_ids.shape[1]))
+                    packets_frac.append(np.array([0] * current_fractions.shape[2]))
                 packets_mc_evt.append([event])
                 packets_mc_trk.append(track_ids[itick])
                 packets_frac.append(current_fractions[itick][iadc])


### PR DESCRIPTION
This PR mainly tackles that the sync packets backtracking info has "wrong" shape, which breaks the functions of variable `ASSOCIATION_COUNT_TO_STORE` and `MAX_TRACKS_PER_PIXEL`. The next thing is that I notice we append a mix of array and list for backtracking information since the `results` are casted into np.array's at the beginning of `save_results`, but this change is not essential.