### PR TITLE
Feature signal indexing

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -916,12 +916,18 @@ def run_simulation(input_filename,
                 pixels_tracks_signals = cp.zeros((len(unique_pix),
                                                   len(detector.TIME_TICKS),
                                                   track_pixel_map.shape[1]))
+                overflow_flag = cp.array([0])
                 detsim.sum_pixel_signals[BPG,TPB](pixels_signals,
                                                   signals,
                                                   track_starts,
                                                   pixel_index_map,
                                                   track_pixel_map,
-                                                  pixels_tracks_signals)
+                                                  pixels_tracks_signals,
+                                                  overflow_flag)
+                if overflow_flag[0]:
+                    warnings.warn("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value, "
+                                  + f"{detsim.MAX_TRACKS_PER_PIXEL}")
+
                 RangePop()
 
                 RangePush("get_adc_values")

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -916,7 +916,7 @@ def run_simulation(input_filename,
                 pixels_tracks_signals = cp.zeros((len(unique_pix),
                                                   len(detector.TIME_TICKS),
                                                   track_pixel_map.shape[1]))
-                overflow_flag = cp.array([0])
+                overflow_flag = cp.zeros(len(unique_pix))
                 detsim.sum_pixel_signals[BPG,TPB](pixels_signals,
                                                   signals,
                                                   track_starts,
@@ -924,7 +924,7 @@ def run_simulation(input_filename,
                                                   track_pixel_map,
                                                   pixels_tracks_signals,
                                                   overflow_flag)
-                if overflow_flag[0]:
+                if cp.any(overflow_flag):
                     warnings.warn("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value, "
                                   + f"{detsim.MAX_TRACKS_PER_PIXEL}")
 

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -525,7 +525,7 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
                     break
 
             if counter < 0:
-                overflow_flag[0] = 1
+                overflow_flag[pixel_index] = 1
 
 
 @cuda.jit

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -469,7 +469,8 @@ def sign(x):
     return 1 if x >= 0 else -1
 
 @cuda.jit
-def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, track_pixel_map, pixels_tracks_signals):
+def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, track_pixel_map, pixels_tracks_signals,
+                      overflow_flag):
     """
     This function sums the induced current signals on the same pixel.
     Converting "signals" from per segment to per pixel ("pixel_signals" and "pixels_tracks_signals")
@@ -489,6 +490,8 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
             the unique pixels array and the array containing the pixels for each track.
         pixels_tracks_signals (:obj:`numpy.ndarray`): 3D array that will contain the waveforms
             for each pixel and each track that induced current on the pixel.
+        overflow_flag (:obj:`cp.array`): Single-element output array to indicate whether
+            MAX_TRACKS_PER_PIXEL is insufficient
     """
     # itrk goes up to the total number of the segments in this batch
     # ipix goes up to the max number of pixel for any segment
@@ -522,7 +525,7 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
                     break
 
             if counter < 0:
-                print("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value, ", MAX_TRACKS_PER_PIXEL)
+                overflow_flag[0] = 1
 
 
 @cuda.jit

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -522,7 +522,7 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
                     break
 
             if counter < 0:
-                print("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value.")
+                print("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value, ", MAX_TRACKS_PER_PIXEL)
 
 
 @cuda.jit

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -542,6 +542,9 @@ def get_track_pixel_map(track_pixel_map, unique_pix, pixels):
             track.
     """
     # index of unique_pix array
+    # although this function could get rid of some segments depending on MAX_TRACKS_PER_PIXEL
+    # the index is with respect to the total number segments in the batch
+    # so when it is translated to "segment_id", it is correct
     index = cuda.grid(1)
 
     upix = unique_pix[index]

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -14,7 +14,7 @@ from numba.cuda.random import xoroshiro128p_normal_float32
 from .consts import detector
 from .pixels_from_track import id2pixel
 
-MAX_TRACKS_PER_PIXEL = 20
+MAX_TRACKS_PER_PIXEL = 50
 MIN_STEP_SIZE = 0.001 # cm
 MC_SAMPLE_MULTIPLIER = 1
 
@@ -506,7 +506,7 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
         if pixel_index >= 0:
             counter = -99
             for track_idx in range(track_pixel_map[pixel_index].shape[0]):
-                if itrk == -1:
+                if itrk == -1: # would itrk ever be -1?
                     continue
                 if itrk == int(track_pixel_map[pixel_index][track_idx]):
                     counter = track_idx
@@ -520,6 +520,9 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
                                             (pixel_index, itime, counter),
                                             signals[itrk][ipix][itick])
                     break
+
+            if counter < 0:
+                print("More segments per pixel than the set MAX_TRACKS_PER_PIXEL value.")
 
 
 @cuda.jit

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -25,7 +25,7 @@ from .consts import units
 #: Number of back-tracked segments to be recorded
 ASSOCIATION_COUNT_TO_STORE = 10
 #: Maximum number of ADC values stored per pixel
-MAX_ADC_VALUES = 20
+MAX_ADC_VALUES = 30
 #: Discrimination threshold in e-
 DISCRIMINATION_THRESHOLD = 7e3 * e
 #: ADC hold delay in clock cycles


### PR DESCRIPTION
1. Corrected an indexing error in sum_pixel_signals
2. Increased `MAX_TRACKS_PER_PIXEL` from 20 to 50, and `MAX_ADC_VALUES` from 20 to 30. For a MiniRun5 file, you would still get a lot more segments than 50 contributing to a pixel.

The run time is ~50min (I'm not sure if it's due to `MAX_TRACKS_PER_PIXEL` and `MAX_ADC_VALUES`). Without light simulation it's ~30min.

This PR needs the change in PR #229. (I could merge then PR... if it's easier...) 
Bug identified by Kazu