### PR TITLE
Hotfix threshold change

### DIFF
--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -53,9 +53,9 @@ GAIN = 4 * mV / (1e3 * e)
 #: Buffer risetime in :math:`\mu s` (set >0 to include buffer response simulation)
 BUFFER_RISETIME = 0.100
 #: Common-mode voltage in :math:`mV`
-V_CM = 288 * mV
+V_CM = 478 * mV
 #: Reference voltage in :math:`mV`
-V_REF = 1300 * mV
+V_REF = 1568 * mV
 #: Pedestal voltage in :math:`mV`
 V_PEDESTAL = 580 * mV
 #: Number of ADC counts

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -28,7 +28,7 @@ ASSOCIATION_COUNT_TO_STORE = 10
 #: Maximum number of ADC values stored per pixel
 MAX_ADC_VALUES = 30
 #: Discrimination threshold in e-
-DISCRIMINATION_THRESHOLD = 7e3 * e
+DISCRIMINATION_THRESHOLD = 5e3 * e
 #: ADC hold delay in clock cycles
 ADC_HOLD_DELAY = 15
 #: ADC busy delay in clock cycles


### PR DESCRIPTION
Adjusting default pixel threshold to be closer to what was achieved during recent 2x2 operations:

![image](https://github.com/user-attachments/assets/0b1ccb5d-a1f8-4d12-b970-d43de338c3e3)

Similar adjustments made to V_ref and V_cm as well.