### PR TITLE
NDLAr Specific Additions (Included in latest `MicroProd`)

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -815,6 +815,7 @@ def run_simulation(input_filename,
         trajectory_ids_arr = cp.asarray(trajectory_ids)
 
         # We divide the sample in portions that can be processed by the GPU
+        is_first_batch = True
         is_new_event = True
         event_id_buffer = -1
         logger.start()
@@ -827,6 +828,12 @@ def run_simulation(input_filename,
         # X is set by "sim.EVENT_BATCH_SIZE" and can be any number
         for ievd, batch_mask in tqdm(batching.TPCBatcher(all_mod_tracks, tracks, sim.EVENT_SEPARATOR, tpc_batch_size=sim.EVENT_BATCH_SIZE, tpc_borders=det_borders),
                                desc='Simulating batches...', ncols=80, smoothing=0):
+            if is_first_batch:
+                this_ievd = ievd
+            if this_ievd != ievd:
+                is_new_event = True
+                this_ievd = ievd
+                
             i_batch = i_batch+1
             # Grab segments from the current batch
             # If there are no segments in the batch, we still check if we need to generate null light signals
@@ -850,8 +857,9 @@ def run_simulation(input_filename,
                         fee.export_sync_to_hdf5(output_filename, sync_times_export, i_mod)
                         sync_start = sync_times[-1] + fee.CLOCK_RESET_PERIOD * fee.CLOCK_CYCLE
                 # beam trigger is only forwarded to one specific pacman (defined in fee)
-                if (light.LIGHT_TRIG_MODE == 0 or light.LIGHT_TRIG_MODE == 1) and (i_mod == trig_module or i_mod == -1):
+                if (light.LIGHT_TRIG_MODE == 0 or light.LIGHT_TRIG_MODE == 1) and (i_mod == trig_module or (i_mod == -1 and is_new_event)):
                     fee.export_timestamp_trigger_to_hdf5(output_filename, this_event_time, i_mod)
+                    is_new_event = False
 
             # generate light waveforms for null signal in the module
             # so we can have light waveforms in this case (if the whole detector is triggered together)
@@ -1209,7 +1217,7 @@ def run_simulation(input_filename,
     # FIXME one can merge the beam + threshold for LIGHT_TRIG_MODE = 1 in future
     # once mod2mod variation is enabled, the light threshold triggering does not work properly
     # compare the light trigger between different module and digitize afterwards should solve the issue
-    if light.LIGHT_TRIG_MODE == 1:
+    if light.LIGHT_TRIG_MODE == 1 and light.LIGHT_SIMULATED:
         light_event_id = np.unique(localSpillIDs) if sim.IS_SPILL_SIM else vertices['event_id']
         light_start_times = np.full(len(light_event_id), 0) # if it is beam trigger it is set to 0
         light_trigger_idx = np.full(len(light_event_id), 0) # one beam spill, one trigger

--- a/larndsim/consts/light.py
+++ b/larndsim/consts/light.py
@@ -170,3 +170,5 @@ def set_light_properties(detprop_file):
 
     except KeyError:
         LIGHT_SIMULATED = False
+        LIGHT_TRIG_MODE = int(detprop.get('light_trig_mode', LIGHT_TRIG_MODE))
+        assert LIGHT_TRIG_MODE in (0,1)

--- a/larndsim/detector_properties/ndlar-module.yaml
+++ b/larndsim/detector_properties/ndlar-module.yaml
@@ -257,6 +257,4 @@ light_trig_mode: 1
 #light_trig_window: [0.9, 1.66] # us
 ## TODO: light_digit_sample_spacing: ?
 #light_nbit: 10
-# The triggers are forwarded regardless of whether light is simulated.
-light_trig_mode: 1
 #lut_vox_div: [14, 26, 8]

--- a/larndsim/detector_properties/ndlar-module.yaml
+++ b/larndsim/detector_properties/ndlar-module.yaml
@@ -257,5 +257,6 @@ light_trig_mode: 1
 #light_trig_window: [0.9, 1.66] # us
 ## TODO: light_digit_sample_spacing: ?
 #light_nbit: 10
-#light_trig_mode: 0
+# The triggers are forwarded regardless of whether light is simulated.
+light_trig_mode: 1
 #lut_vox_div: [14, 26, 8]


### PR DESCRIPTION
A couple of commits that featured in the latest NDLAr `MicroProds` introducing two things. Want to bring these into develop.

- We only want to create a trigger packet when we have a new event, not necessary a new batch. Logic introduced applies when not running in `mod2mod_variation` mode. The reason being you don't want to set your "trigger module" to minus 1. See logic at line 860 of `simulate_pixels`.
- A temporary solution to run in "light trigger mode" without the need to simulate the light (which we haven't tried for NDLAr).