### PR TITLE
Feature simple jagged

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1053,7 +1053,7 @@ def run_simulation(input_filename,
                 # note track_pixel_map has shape (#unique pix, max tracks per pixel)
                 # num_backtrack has shape of (#unique pix,)
                 num_backtrack = cp.sum(track_pixel_map != -1, axis=-1)
-                offset_backtrack = cp.cumsum(num_backtrack)
+                offset_backtrack = cp.cumsum(num_backtrack) - num_backtrack[0]
                 # pixels_tracks_signals is a jagged array of dimension (#unique_pix, #ticks, backtracked_segments)
                 # where the segments are jagged
                 pixels_tracks_signals = cp.zeros(len(detector.TIME_TICKS) * int(num_backtrack.sum()))

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -500,7 +500,7 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
 
     itrk, ipix, itick = cuda.grid(3)
 
-    vals_per_tick = offset_backtrack[-1] # #pix * backtracks
+    vals_per_tick = offset_backtrack[-1] + num_backtrack[0] # #pix * backtracks
 
     if itrk < signals.shape[0] and ipix < signals.shape[1]:
 
@@ -512,7 +512,6 @@ def sum_pixel_signals(pixels_signals, signals, track_starts, pixel_index_map, tr
 
         if pixel_index >= 0:
             counter = -99
-            # NOTE: Could instead use num_backtrack here
             for track_idx in range(track_pixel_map[pixel_index].shape[0]):
                 if itrk == -1: # would itrk ever be -1?
                     continue

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -549,7 +549,7 @@ def get_adc_values(pixels_signals,
     """
     ip = cuda.grid(1)
 
-    vals_per_tick = offset_backtrack[-1] # #pix * backtracks
+    vals_per_tick = offset_backtrack[-1] + num_backtrack[0] # #pix * backtracks
 
     ntrks = min(num_backtrack[ip], current_fractions.shape[2])
 

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -551,6 +551,8 @@ def get_adc_values(pixels_signals,
 
     vals_per_tick = offset_backtrack[-1] # #pix * backtracks
 
+    ntrks = min(num_backtrack[ip], current_fractions.shape[2])
+
     if ip < pixels_signals.shape[0]:
         curre = pixels_signals[ip]
         ic = 0
@@ -573,13 +575,13 @@ def get_adc_values(pixels_signals,
                     w = exp((jc - ic) * detector.TIME_SAMPLING / detector.BUFFER_RISETIME) * (1 - exp(-detector.TIME_SAMPLING/detector.BUFFER_RISETIME))
                     q += curre[jc] * detector.TIME_SAMPLING * w
 
-                    for itrk in range(num_backtrack[ip]):
+                    for itrk in range(ntrks):
                         idx = vals_per_tick * jc + offset_backtrack[ip] + itrk
                         current_fractions[ip][iadc][itrk] += pixels_signals_tracks[idx] * detector.TIME_SAMPLING * w
 
             elif ic < curre.shape[0]:
                 q += curre[ic] * detector.TIME_SAMPLING
-                for itrk in range(num_backtrack[ip]):
+                for itrk in range(ntrks):
                     idx = vals_per_tick * ic + offset_backtrack[ip] + itrk
                     current_fractions[ip][iadc][itrk] += pixels_signals_tracks[idx] * detector.TIME_SAMPLING
 
@@ -607,13 +609,13 @@ def get_adc_values(pixels_signals,
                             w = exp((jc - ic) * detector.TIME_SAMPLING / detector.BUFFER_RISETIME) * (1 - exp(-detector.TIME_SAMPLING/detector.BUFFER_RISETIME))
                             q += curre[jc] * detector.TIME_SAMPLING * w
 
-                            for itrk in range(num_backtrack[ip]):
+                            for itrk in range(ntrks):
                                 idx = vals_per_tick * jc + offset_backtrack[ip] + itrk
                                 current_fractions[ip][iadc][itrk] += pixels_signals_tracks[idx] * detector.TIME_SAMPLING * w
 
                     elif ic < curre.shape[0]:
                         q += curre[ic] * detector.TIME_SAMPLING
-                        for itrk in range(num_backtrack[ip]):
+                        for itrk in range(ntrks):
                             idx = vals_per_tick * ic + offset_backtrack[ip] + itrk
                             current_fractions[ip][iadc][itrk] += pixels_signals_tracks[idx] * detector.TIME_SAMPLING
 


### PR DESCRIPTION
Converts the bloated `pixels_tracks_signals` 3D array into a (2+1)D ad-hoc jagged array. It's ugly but it makes a ~50% difference in worst-case memory consumption. It would be nice to have a higher-level abstraction that hides the indexing arithmetic.