### PR TITLE
Prevent out of bounds indexing error

### DIFF
--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -550,7 +550,8 @@ def get_track_pixel_map(track_pixel_map, unique_pix, pixels):
     # the index is with respect to the total number segments in the batch
     # so when it is translated to "segment_id", it is correct
     index = cuda.grid(1)
-
+    if index >= unique_pix.shape[0]:
+        return
     upix = unique_pix[index]
 
     for itrk in range(pixels.shape[0]):
@@ -582,7 +583,8 @@ def get_track_pixel_map2(track_pixel_map, unique_pix, pixels, distances, max_dis
     """
     # index of unique_pix array
     index = cuda.grid(1)
-
+    if index >= unique_pix.shape[0]:
+        return
     upix = unique_pix[index]
 
     for target_dist in range(max_distance):


### PR DESCRIPTION
In `detsim.get_track_pixel_map2`, it is possible that the function will try to index into `unique_pix` with an index > unique_pix.shape[0], causing an error. To prevent this, I add a simple check if the index is >= unique_pix.shape[0], if so return. This is similar to other implementations in other functions that prevent such an indexing error.

For reference, here is an example error I get without this change:

> Simulating batches...:   0%|                | 137/52228 [00:06<41:17, 21.03it/s]/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/cli/simulate_pixels.py:1123: UserWarning: 
> Traceback (most recent call last):                                              
>   File "/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/cli/simulate_pixels.py", line 1376, in <module>
>     fire.Fire(run_simulation)                                                   
>   File "/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/larndsim.venv/lib/python3.11/site-packages/fire/core.py", line 135, in Fire
>     component_trace = _Fire(component, args, parsed_flag_args, context, name)
>                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
>   File "/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/larndsim.venv/lib/python3.11/site-packages/fire/core.py", line 468, in _Fire
>     component, remaining_args = _CallAndUpdateTrace(
>                                 ^^^^^^^^^^^^^^^^^^^^
>   File "/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/larndsim.venv/lib/python3.11/site-packages/fire/core.py", line 684, in _CallAndUpdateTrace
>     component = fn(*varargs, **kwargs)
>                 ^^^^^^^^^^^^^^^^^^^^^^
>   File "/pscratch/sd/s/sfogarty/2x2_MC_job/larnd-sim/cli/simulate_pixels.py", line 1106, in run_simulation
>     pixels_tracks_signals = cp.zeros(len(detector.TIME_TICKS) * int(num_backtrack.sum()))
>                                                                 ^^^^^^^^^^^^^^^^^^^^^^^^
>   File "cupy/_core/core.pyx", line 1771, in cupy._core.core._ndarray_base.__int__
>   File "cupy/_core/core.pyx", line 1910, in cupy._core.core._ndarray_base.get
>   File "cupy/cuda/memory.pyx", line 586, in cupy.cuda.memory.MemoryPointer.copy_to_host_async
>   File "cupy_backends/cuda/api/runtime.pyx", line 607, in cupy_backends.cuda.api.runtime.memcpyAsync
>   File "cupy_backends/cuda/api/runtime.pyx", line 146, in cupy_backends.cuda.api.runtime.check_status
> cupy_backends.cuda.api.runtime.CUDARuntimeError: cudaErrorIllegalAddress: an illegal memory access was encountered
> ERROR:numba.cuda.cudadrv.driver:Call to cuModuleUnload results in UNKNOWN_CUDA_ERROR