### PR TITLE
Don't generate ionization electrons and scint for gamma/neutron segments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ docs/build
 .vscode
 examples/module0_corsika.h5
 test
+*.*.swp

--- a/larndsim/quenching.py
+++ b/larndsim/quenching.py
@@ -25,20 +25,29 @@ def quench(tracks, mode):
     if itrk < tracks.shape[0]:
         dEdx = tracks[itrk]["dEdx"]
         dE = tracks[itrk]["dE"]
+        # TODO: ensure 'dE' is visible energy (may require subtracting off the SecondaryEnergyDeposit
+        #       calculated by edepsim that accounts for non-ionizing energy loss)
+        
+        # initialize to zero
+        tracks[itrk]["n_electrons"] = 0
+        tracks[itrk]["n_photons"]   = 0
 
-        recomb = 0
-        if mode == physics.BOX:
-            # Baller, 2013 JINST 8 P08005
-            csi = physics.BOX_BETA * dEdx / (detector.E_FIELD * detector.LAR_DENSITY)
-            recomb = max(0, log(physics.BOX_ALPHA + csi)/csi)
-        elif mode == physics.BIRKS:
-            # Amoruso, et al NIM A 523 (2004) 275
-            recomb = physics.BIRKS_Ab / (1 + physics.BIRKS_kb * dEdx / (detector.E_FIELD * detector.LAR_DENSITY))
-        else:
-            raise ValueError("Invalid recombination mode: must be 'physics.BOX' or 'physics.BIRKS'")
+        # if this isn't a gamma or neutron, calculate charge/light
+        pdg = tracks[itrk]["pdg_id"]
+        if dEdx > 0 and pdg != 22 and pdg != 2112:
+            recomb = 0
+            if mode == physics.BOX:
+                # Baller, 2013 JINST 8 P08005
+                csi = physics.BOX_BETA * dEdx / (detector.E_FIELD * detector.LAR_DENSITY)
+                recomb = max(0, log(physics.BOX_ALPHA + csi)/csi)
+            elif mode == physics.BIRKS:
+                # Amoruso, et al NIM A 523 (2004) 275
+                recomb = physics.BIRKS_Ab / (1 + physics.BIRKS_kb * dEdx / (detector.E_FIELD * detector.LAR_DENSITY))
+            else:
+                raise ValueError("Invalid recombination mode: must be 'physics.BOX' or 'physics.BIRKS'")
 
-        if isnan(recomb):
-            raise RuntimeError("Invalid recombination value")
-
-        tracks[itrk]["n_electrons"] = recomb * dE / physics.W_ION
-        tracks[itrk]["n_photons"] = (dE/light.W_PH - tracks[itrk]["n_electrons"]) * light.SCINT_PRESCALE
+            if isnan(recomb):
+                raise RuntimeError("Invalid recombination value")
+            
+            tracks[itrk]["n_electrons"] = recomb * dE / physics.W_ION
+            tracks[itrk]["n_photons"]   = (dE/light.W_PH - tracks[itrk]["n_electrons"]) * light.SCINT_PRESCALE


### PR DESCRIPTION
Simple check in `quenching.py` to exclude common neutral particles like gammas and neutrons (with non-zero 'dE') from the charge/light generation process. It's not 100% clear why this happens, but the leading theory is that the total 'dE' returned by edepsim also includes non-ionizing energy loss. A more comprehensive solution would be to find a way to reliably calculate only the ionizing dE and use that in the calculation of `n_electrons` and `n_photons` instead of total dE. This would require upstream changes to the ROOT-to-HDF5 conversion stage.

James Mead ran some code over a 2x2 simulation test file before and after this fix. Before:
![image (3)](https://github.com/user-attachments/assets/53d9f6e1-f6b4-4b59-a7bd-b99e09379971)


After:
![image (4)](https://github.com/user-attachments/assets/482484b2-fbbd-44d2-a298-ef3beda44850)



