### PR TITLE
Feature reproducibility

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -2,7 +2,7 @@
 """
 Command-line interface to larnd-sim module.
 """
-from math import ceil
+from math import ceil, floor
 from time import time
 import warnings
 from collections import defaultdict
@@ -1068,8 +1068,20 @@ def run_simulation(input_filename,
                 BPG_Y = max(ceil(signals.shape[1] / TPB[1]),1)
                 BPG_Z = max(ceil(signals.shape[2] / TPB[2]),1)
                 BPG = (BPG_X, BPG_Y, BPG_Z)
-                rng_states = maybe_create_rng_states(int(np.prod(TPB) * np.prod(BPG)), seed=rand_seed+ievd+itrk, rng_states=rng_states)
-                detsim.tracks_current_mc[BPG,TPB](signals, neighboring_pixels, selected_tracks, response, rng_states)
+
+                BPG_X_subbatch = min(floor(len(rng_states) / (np.prod(TPB) * BPG[1] * BPG[2])), BPG_X)
+                BPG_subbatch = (BPG_X_subbatch, BPG_Y, BPG_Z)
+                subbatches_size = BPG_X_subbatch
+                n_subbatches = ceil(BPG_X/subbatches_size)
+
+                for i_subbatch in range(n_subbatches):
+                    start = i_subbatch*subbatches_size
+                    end = (i_subbatch+1)*subbatches_size
+                    detsim.tracks_current_mc[BPG_subbatch,TPB](signals[start:end],
+                                                                 neighboring_pixels[start:end],
+                                                                 selected_tracks[start:end],
+                                                                 response, rng_states)
+
                 RangePop()
 
                 RangePush("pixel_index_map")

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -98,7 +98,7 @@ def maybe_create_rng_states(n, seed=0, rng_states=None):
     if n > len(rng_states):
         new_states = device_array(n, dtype=rng_states.dtype)
         new_states[:len(rng_states)] = rng_states
-        new_states[len(rng_states):] = create_xoroshiro128p_states(n - len(rng_states), seed=seed)
+        new_states[len(rng_states):] = create_xoroshiro128p_states(n - len(rng_states), seed=seed, subsequence_start = len(rng_states))
         return new_states
 
     return rng_states
@@ -1159,7 +1159,7 @@ def run_simulation(input_filename,
                 # TPB = 128
                 TPB = 4 #[1, 4, 8, 16, 32, 64, 128, 256]
                 BPG = ceil(pixels_signals.shape[0] / TPB)
-                rng_states = maybe_create_rng_states(int(TPB * BPG), seed=rand_seed+ievd+itrk, rng_states=rng_states)
+                rng_states = maybe_create_rng_states(int(TPB * BPG), seed=rand_seed, rng_states=rng_states)
                 TPB_lut = 128 # supposed to be 128
                 BPG_lut = ceil(pixels_signals.shape[0] / TPB_lut)  
                 if pixel_thresholds_file is not None:
@@ -1252,7 +1252,7 @@ def run_simulation(input_filename,
 
                     light_sample_inc_disc = cp.zeros_like(light_sample_inc)
                     rng_states = maybe_create_rng_states(int(np.prod(TPB) * np.prod(BPG)),
-                                                         seed=rand_seed+ievd+itrk, rng_states=rng_states)
+                                                         seed=rand_seed, rng_states=rng_states)
                     light_sim.calc_stat_fluctuations[BPG, TPB](light_sample_inc_scint, light_sample_inc_disc, rng_states)
                     RangePop()
 

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1068,7 +1068,7 @@ def run_simulation(input_filename,
                 BPG_Y = max(ceil(signals.shape[1] / TPB[1]),1)
                 BPG_Z = max(ceil(signals.shape[2] / TPB[2]),1)
                 BPG = (BPG_X, BPG_Y, BPG_Z)
-                rng_states = maybe_create_rng_states(int(np.prod(TPB[:2]) * np.prod(BPG[:2])), seed=rand_seed+ievd+itrk, rng_states=rng_states)
+                rng_states = maybe_create_rng_states(int(np.prod(TPB) * np.prod(BPG)), seed=rand_seed+ievd+itrk, rng_states=rng_states)
                 detsim.tracks_current_mc[BPG,TPB](signals, neighboring_pixels, selected_tracks, response, rng_states)
                 RangePop()
 

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -111,7 +111,7 @@ def tracks_current_mc(signals, pixels, tracks, response, rng_states):
             generation
     """
     itrk, ipix, it = cuda.grid(3)
-    ntrk, _, _ = cuda.gridsize(3)
+    ntrk, npix, nt = cuda.gridsize(3)
 
     if itrk < signals.shape[0] and ipix < signals.shape[1] and it < signals.shape[2]:
         t = tracks[itrk]
@@ -166,13 +166,12 @@ def tracks_current_mc(signals, pixels, tracks, response, rng_states):
 
             charge = t["n_electrons"] * (subsegment_length/length) / nstep
             total_current = 0
-            rng_state = (rng_states[itrk + ntrk * ipix],)
             for istep in range(nstep):
                 x = subsegment_start[0] + step * (istep + 0.5) * direction[0]
                 y = subsegment_start[1] + step * (istep + 0.5) * direction[1]
                 z = subsegment_start[2] + step * (istep + 0.5) * direction[2]
 
-                z += xoroshiro128p_normal_float32(rng_state, 0) * sigmas[2]
+                z += xoroshiro128p_normal_float32(rng_states, itrk * npix * nt + ipix * nt + it ) * sigmas[2]
 
                 # find how much to shift the time for anode (collection time)
                 # detector.TPC_BORDERS[t["pixel_plane"]][2][0] is anode
@@ -180,8 +179,8 @@ def tracks_current_mc(signals, pixels, tracks, response, rng_states):
                 # equivalent to detector.DRIFT_LENGTH - abs(z - detector.TPC_BORDERS[t["pixel_plane"]][2][1])
                 shift_t_collect = abs(z - detector.TPC_BORDERS[t["pixel_plane"]][2][1]) / detector.V_DRIFT
 
-                x += xoroshiro128p_normal_float32(rng_state, 0) * sigmas[0]
-                y += xoroshiro128p_normal_float32(rng_state, 0) * sigmas[1]
+                x += xoroshiro128p_normal_float32(rng_states, itrk * npix * nt + ipix * nt + it ) * sigmas[0]
+                y += xoroshiro128p_normal_float32(rng_states, itrk * npix * nt + ipix * nt + it ) * sigmas[1]
                 x_dist = abs(x_p - x)
                 y_dist = abs(y_p - y)
 


### PR DESCRIPTION
A work in progress for adding reproducibility to larnd-sim. Looks to resolve issue #125.

Current status: reproducibility seems to be there. Need to look at the flow outputs and see if it's sensible. Need to check if time consumption increases appreciably. Maybe other improvements? 

In the develop branch:
The `signals` [variable](https://github.com/DUNE/larnd-sim/blob/ad3fe922768b185600c6bc4cb4f6dd28d807c308/cli/simulate_pixels.py#L1063) contains the output of the induced signal on each relevant pixel from each segment. It has a shape of (# of segments x # of neighboring pixels x # time ticks). 
When [filling](https://github.com/DUNE/larnd-sim/blob/ad3fe922768b185600c6bc4cb4f6dd28d807c308/cli/simulate_pixels.py#L1072) in `signals` in `tracks_current_mc`, a thread is created for each element in the `signals` array and each thread samples from an RNG in the `rng_states` array.  In the current implementation it looks like, for each element in the first and second dimension, all the threads in the third dimension [samples from the same rng state](https://github.com/DUNE/larnd-sim/blob/ad3fe922768b185600c6bc4cb4f6dd28d807c308/larndsim/detsim.py#L169). This would lead to non-reproducibility. 

My branch:
I first change the `tracks_current_mc` function so that each [thread samples from a different rng state](https://github.com/DUNE/larnd-sim/blob/88497ce1b4fa4d48af50e107da139c7fb8b1cfcc/larndsim/detsim.py#L174). This seemed to result in reproducibility.  But this leads to another issue where, when creating enough rng states for an event with a very large signals.size, the job would run out of memory and crash. This first change is contained in this [commit](https://github.com/DUNE/larnd-sim/commit/0279e002f468eaf1e7f401ac9f78414aa98d57f2). 
My solution is that when we reach an event where more rng_states are needed to accommodate `signals`, `signals` is instead [batched](https://github.com/DUNE/larnd-sim/blob/88497ce1b4fa4d48af50e107da139c7fb8b1cfcc/cli/simulate_pixels.py#L1077) so that each batch is accommodated within the existing number of rng_states. 
Initial checks seem to give reproducibility, with no appreciable increase in run time. 

There are probably improvements that can be made. The batch sizes are determined by the size of `rng_states`, whose size is variable (but made to only grow) and changes based on other lines in the code. Maybe an optimal number can be determined before hand. 
Also, maybe the batching can be expanded to surround other steps in the code? Or maybe batching `tracks_current_mc` is enough to solve Matt's goal of reducing memory usage? Or maybe replacing `signals` with an awkward array removes all need for batching? 