### PR TITLE
Hackathon2025 Improvements

### DIFF
--- a/cli/diff_files.py
+++ b/cli/diff_files.py
@@ -1,0 +1,85 @@
+#!/usr/bin/env python
+
+import sys, time
+import argparse
+import h5py
+import numpy as np
+
+np.set_printoptions(precision=3)
+
+parser = argparse.ArgumentParser()
+parser.add_argument('--ref_file', default=None, type=str, help='path of the larnd-sim reference simulation file to be considered')
+parser.add_argument('--sim_file', default=None, type=str, help='path of the larnd-sim output simulation file to be considered')
+parser.add_argument('--strict', default=False, action='store_true', help='enable strict comparisons')
+parser.add_argument('--verbose', default=False, action='store_true', help='print summary statistics in addition to warnings')
+args = parser.parse_args()
+
+def check_dataset(ref_file, sim_file, dset_name):
+    print(f"Checking {dset_name} ...")
+    ref_dataset = ref_file[dset_name]
+    sim_dataset = sim_file[dset_name]
+    struct_names = ref_dataset.dtype.names
+
+    if struct_names is not None:
+        for name in ref_dataset.dtype.names:
+            if args.strict:
+                indices = np.nonzero(ref_dataset[name, :] != sim_dataset[name, :])
+            else:
+                indices = np.nonzero(~np.isclose(ref_dataset[name, :], sim_dataset[name, :]))
+
+            all_empty = np.all(np.array([arr.size == 0 for arr in indices]))
+            if not all_empty:
+                print(f"Mismatching {dset_name}/{name}!")
+                print("Index locations of mismatch.")
+                print(indices)
+            else:
+                print(f"{dset_name}/{name} match.")
+    else:
+        if args.strict:
+            indices = np.nonzero(ref_dataset[:] != sim_dataset[:])
+        else:
+            indices = np.nonzero(~np.isclose(ref_dataset[:], sim_dataset[:]))
+
+        all_empty = np.all(np.array([arr.size == 0 for arr in indices]))
+        if not all_empty:
+            print(f"Mismatching {dset_name}!")
+            print("Index locations of mismatch.")
+            print(indices)
+        else:
+            print(f"{dset_name} match.")
+    print("---------------------------")
+
+print("-----------------------------------------")
+print("Comparing larnd-sim simulation outputs...")
+print(f"Reference file : {args.ref_file}")
+print(f"Simulation file: {args.sim_file}")
+
+ref_file = h5py.File(args.ref_file)
+sim_file = h5py.File(args.sim_file)
+print("-------------------")
+print("Opened files...")
+
+t_start = time.time()
+failed_tests = 0
+
+# for dset in ref_file.keys():
+    # check_dataset(ref_file, sim_file, dset)
+print("Testing datasets...")
+print("-------------------")
+check_dataset(ref_file, sim_file, 'segments')
+check_dataset(ref_file, sim_file, 'packets')
+check_dataset(ref_file, sim_file, 'mc_packets_assn')
+check_dataset(ref_file, sim_file, 'light_wvfm')
+check_dataset(ref_file, sim_file, 'light_trig')
+check_dataset(ref_file, sim_file, 'light_wvfm_mc_assn')
+
+t_end = time.time()
+t_elapse = t_end - t_start
+print(f"Elapsed time: {t_elapse:.3f} s")
+print(f"Failed tests: {failed_tests}")
+print("Finished.")
+
+if failed_tests > 0:
+    sys.exit(121)
+else:
+    sys.exit(0)

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1284,9 +1284,11 @@ def run_simulation(input_filename,
                     light_sample_inc_scint = cp.zeros_like(light_sample_inc)
                     light_sample_inc_scint_true_track_id = cp.full_like(light_sample_inc_true_track_id, -1)
                     light_sample_inc_scint_true_photons = cp.zeros_like(light_sample_inc_true_photons)
+                    scint_model = np.zeros(n_light_ticks, dtype=np.float32)
+                    light_sim.scintillation_array(scint_model)
                     light_sim.calc_scintillation_effect[BPG, TPB](
                         light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_sample_inc_scint,
-                        light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons)
+                        light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons, scint_model)
 
                     light_sample_inc_disc = cp.zeros_like(light_sample_inc)
                     rng_states = maybe_create_rng_states(int(np.prod(TPB) * np.prod(BPG)),

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1296,9 +1296,11 @@ def run_simulation(input_filename,
                     light_response = cp.zeros_like(light_sample_inc)
                     light_response_true_track_id = cp.full_like(light_sample_inc_true_track_id, -1)
                     light_response_true_photons = cp.zeros_like(light_sample_inc_true_photons)
+                    sipm_response = np.zeros(n_light_ticks, dtype=np.float32)
+                    light_sim.sipm_response_fast(sipm_response) #precalculate the sipm_response
                     light_sim.calc_light_detector_response[BPG, TPB](
                         light_sample_inc_disc, light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons,
-                        light_response, light_response_true_track_id, light_response_true_photons, light_gain)
+                        light_response, light_response_true_track_id, light_response_true_photons, light_gain, sipm_response)
                     #light_response += cp.array(light_sim.gen_light_detector_noise(light_response.shape, light_noise[op_channel.get()]))
                     RangePop()
 

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1299,7 +1299,7 @@ def run_simulation(input_filename,
                     light_response_true_track_id = cp.full_like(light_sample_inc_true_track_id, -1)
                     light_response_true_photons = cp.zeros_like(light_sample_inc_true_photons)
                     sipm_response = np.zeros(n_light_ticks, dtype=np.float32)
-                    light_sim.sipm_response_fast(sipm_response) #precalculate the sipm_response
+                    light_sim.sipm_response_array(sipm_response) #precalculate the sipm_response
                     light_sim.calc_light_detector_response[BPG, TPB](
                         light_sample_inc_disc, light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons,
                         light_response, light_response_true_track_id, light_response_true_photons, light_gain, sipm_response)

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1115,11 +1115,13 @@ def run_simulation(input_filename,
 
                 RangePush("pixel_index_map")
                 # Here we create a map between tracks and index in the unique pixel array
-                pixel_index_map = cp.full((selected_tracks.shape[0], neighboring_pixels.shape[1]), -1)
-                for i_ in range(selected_tracks.shape[0]):
-                    compare = neighboring_pixels[i_, ..., cp.newaxis] == unique_pix
-                    indices = cp.where(compare)
-                    pixel_index_map[i_, indices[0]] = indices[1]
+                # First, create a lookup table for unique_pix values to their indices
+                max_pix_val = int(cp.max(unique_pix)) + 1
+                pix_lookup = cp.full((max_pix_val,), -1, dtype=cp.int32)
+                pix_lookup[unique_pix] = cp.arange(unique_pix.shape[0], dtype=cp.int32)
+                
+                # Now directly map neighboring_pixels to pixel indices using lookup
+                pixel_index_map = pix_lookup[neighboring_pixels]
                 RangePop()
 
                 RangePush("track_pixel_map")

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -532,7 +532,7 @@ def digitize(integral_list, gain=detector.GAIN * mV / e, pedestal=detector.V_PED
     return adcs
 
 # @cuda.jit
-@cuda.jit(max_registers=64)
+@cuda.jit(max_registers=128)
 def get_adc_values(pixels_signals,
                    pixels_signals_tracks,
                    num_backtrack,

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -144,9 +144,23 @@ def scintillation_model(time_tick):
     p3 = (1 - light.SINGLET_FRACTION) * exp(-time_tick * light.LIGHT_TICK_SIZE / light.TAU_T) * (1 - exp(-light.LIGHT_TICK_SIZE / light.TAU_T))
     return (p1 + p3) * (time_tick >= 0)
 
+@nb.njit
+def scintillation_array(scint_model):
+    """
+    Calculates the fraction of scintillation photons emitted 
+    during time interval `time_tick` to `time_tick + 1` for
+    the entire input array.
+    
+    Args:
+        scint_model: array to store result
+    """
+    for time_tick in range(scint_model.shape[0]):
+        p1 = light.SINGLET_FRACTION * exp(-time_tick * light.LIGHT_TICK_SIZE / light.TAU_S) * (1 - exp(-light.LIGHT_TICK_SIZE / light.TAU_S))
+        p3 = (1 - light.SINGLET_FRACTION) * exp(-time_tick * light.LIGHT_TICK_SIZE / light.TAU_T) * (1 - exp(-light.LIGHT_TICK_SIZE / light.TAU_T))
+        scint_model[time_tick] = p1 + p3
 
 @cuda.jit
-def calc_scintillation_effect(light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_sample_inc_scint, light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons):
+def calc_scintillation_effect(light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_sample_inc_scint, light_sample_inc_scint_true_track_id, light_sample_inc_scint_true_photons, scint_model):
     """
     Applies a smearing effect due to the liquid argon scintillation time profile using
     a two decay component scintillation model.
@@ -164,7 +178,7 @@ def calc_scintillation_effect(light_sample_inc, light_sample_inc_true_track_id, 
             for jtick in range(max(itick - conv_ticks, 0), itick+1):
                 if light_sample_inc[idet,jtick] == 0:
                     continue
-                tick_weight = scintillation_model(itick-jtick)
+                tick_weight = scint_model[itick-jtick]
                 light_sample_inc_scint[idet,itick] += tick_weight * light_sample_inc[idet,jtick]
 
                 # loop over convolution tick truth

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -269,8 +269,8 @@ def interp(idx, arr, low, high):
     v1 = arr[i1]
     return v0 + (v1 - v0) * (idx - i0)
 
-@nb.njit
-def sipm_response_model(idet, time_tick):
+@nb.njit()
+def sipm_response_model(time_tick):
     """
     Calculates the SiPM response from a PE at `time_tick` relative to the PE time
     
@@ -296,10 +296,15 @@ def sipm_response_model(idet, time_tick):
         # normalize to 1
         impulse /=  light.IMPULSE_TICK_SIZE/light.LIGHT_TICK_SIZE
         return impulse
-            
+
+@nb.njit()
+def sipm_response_fast(sipm_response):
+    for time_tick in range(sipm_response.shape[0]):
+        sipm_response[time_tick] = interp(time_tick * light.LIGHT_TICK_SIZE / light.IMPULSE_TICK_SIZE, light.IMPULSE_MODEL, 0, 0)
+    sipm_response /= light.IMPULSE_TICK_SIZE/light.LIGHT_TICK_SIZE
 
 @cuda.jit
-def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_response, light_response_true_track_id, light_response_true_photons, light_gain):
+def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_response, light_response_true_track_id, light_response_true_photons, light_gain, sipm_response):
     """
     Simulates the SiPM reponse and digit
     
@@ -314,7 +319,7 @@ def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_i
             conv_ticks = ceil((light.LIGHT_WINDOW[1] - light.LIGHT_WINDOW[0])/light.LIGHT_TICK_SIZE)
             
             for jtick in range(max(itick - conv_ticks, 0), itick+1):
-                tick_weight = sipm_response_model(idet, itick-jtick)
+                tick_weight = sipm_response[itick-jtick]
                 light_response[idet,itick] += light_gain[idet] * tick_weight * light_sample_inc[idet,jtick]
                     
                 # loop over convolution tick truth

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -298,10 +298,25 @@ def sipm_response_model(time_tick):
         return impulse
 
 @nb.njit()
-def sipm_response_fast(sipm_response):
-    for time_tick in range(sipm_response.shape[0]):
-        sipm_response[time_tick] = interp(time_tick * light.LIGHT_TICK_SIZE / light.IMPULSE_TICK_SIZE, light.IMPULSE_MODEL, 0, 0)
-    sipm_response /= light.IMPULSE_TICK_SIZE/light.LIGHT_TICK_SIZE
+def sipm_response_array(sipm_response):
+    """
+    Calculates the SiPM response from a PE at every `time_tick` relative to the PE time
+    for the given array
+    
+    Args:
+        sipm_response: array to store response
+    """
+    if light.SIPM_RESPONSE_MODEL == 0:
+        for time_tick in range(sipm_response.shape[0]):
+            t = time_tick * light.LIGHT_TICK_SIZE
+            sipm_response[time_tick] = (t>=0) * exp(-t/light.LIGHT_RESPONSE_TIME) * sin(t/light.LIGHT_OSCILLATION_PERIOD)
+        sipm_response /= light.LIGHT_OSCILLATION_PERIOD * light.LIGHT_RESPONSE_TIME**2
+        sipm_response *= light.LIGHT_OSCILLATION_PERIOD**2 + light.LIGHT_RESPONSE_TIME**2
+
+    if light.SIPM_RESPONSE_MODEL == 1:
+        for time_tick in range(sipm_response.shape[0]):
+            sipm_response[time_tick] = interp(time_tick * light.LIGHT_TICK_SIZE / light.IMPULSE_TICK_SIZE, light.IMPULSE_MODEL, 0, 0)
+        sipm_response /= light.IMPULSE_TICK_SIZE/light.LIGHT_TICK_SIZE
 
 @cuda.jit
 def calc_light_detector_response(light_sample_inc, light_sample_inc_true_track_id, light_sample_inc_true_photons, light_response, light_response_true_track_id, light_response_true_photons, light_gain, sipm_response):

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -267,9 +267,7 @@ def interp(idx, arr, low, high):
     i1 = i0 + 1
     v0 = arr[i0]
     v1 = arr[i1]
-
     return v0 + (v1 - v0) * (idx - i0)
-                
 
 @nb.njit
 def sipm_response_model(idet, time_tick):
@@ -631,33 +629,34 @@ def zero_suppress_waveform_truth(waveforms_true_track_id, waveforms_true_photons
         i_mod(int): module id. The default value is -1 which indicates that there is no modular variation activated.
 
     Returns:
-        1D array which logs ['trigger_id', 'op_channel_id', 'tick', 'event_id', 'segment_id', 'pe_current']. The first three locate a unique data point on arecorded light waveform, and the last three provide the truth information associated to it. `event_id` can be infered from `segment_id` but the information helps searching the corresponding reco information from a true event.
+        1D array which logs ['trigger_id', 'op_channel_id', 'tick', 'event_id', 'segment_id', 'pe_current']. The first three locate a unique data point on a recorded light waveform, and the last three provide the truth information associated to it. `event_id` can be infered from `segment_id` but the information helps searching the corresponding reco information from a true event.
     """
 
     op_channel = light.TPC_TO_OP_CHANNEL[(i_mod-1)*2:i_mod*2].ravel() if i_mod > 0 else light.TPC_TO_OP_CHANNEL[:].ravel()
 
-    event_id, trigger_id, op_channel_id, segment_id, pe_current, tick = [[] for i in range(6)]
-    indices = [index for index, x in np.ndenumerate(waveforms_true_track_id) if x!=-1]
+    # Get total number of non-default entries
+    mask = waveforms_true_track_id != -1
+    num_idx = np.prod(waveforms_true_track_id[mask].shape)
+    # Get indices of those valid entires and destructure the tuple
+    idx0, idx1, idx2, idx3 = np.nonzero(waveforms_true_track_id != -1)
+
     truth_dtype = np.dtype([('trigger_id', 'i4'), ('op_channel_id','i4'), ('tick','i4'), ('event_id','i4'), ('segment_id','i8'), ('pe_current','f8')])
-    for i in range(len(indices)):
-        this_trig = indices[i][0]
-        i_trig = i_trig + this_trig #FIXME currently indices[i][0] is always 0. probably further change is needed for multiple light triggers in one trueevent
-        i_op_channel = indices[i][1]
-        i_sample = indices[i][2]
-        i_content = indices[i][3]
-        trigger_id.append(i_trig)
-        op_channel_id.append(op_channel[i_op_channel]) # in case of non trivial op channel indexing
-        tick.append(i_sample)
-        event_id.append(i_evt)
-        segment_id.append(waveforms_true_track_id[this_trig][i_op_channel][i_sample][i_content])
-        pe_current.append(waveforms_true_photons[this_trig][i_op_channel][i_sample][i_content])
-    truth_data = np.empty(len(indices), dtype=truth_dtype)
-    truth_data['trigger_id'] = np.array(trigger_id)
-    truth_data['op_channel_id'] = np.array(op_channel_id)
-    truth_data['tick'] = np.array(tick)
-    truth_data['event_id'] = np.array(event_id)
-    truth_data['segment_id'] = np.array(segment_id)
-    truth_data['pe_current'] = np.array(pe_current)
+    truth_data = np.empty(num_idx, dtype=truth_dtype)
+
+    # Careful with all the indices
+    for x, (i, j, k, l) in enumerate(zip(idx0, idx1, idx2, idx3)):
+        this_trig = i #idx0
+        i_trig = i_trig + i #FIXME currently idx0 is always 0. probably further change is needed for multiple light triggers in one trueevent
+        i_op_channel = j #idx1
+        i_sample = k  #idx2
+        i_content = l #idx3
+        truth_data[x]['trigger_id'] = i_trig
+        truth_data[x]['op_channel_id'] = op_channel[i_op_channel]
+        truth_data[x]['tick'] = i_sample
+        truth_data[x]['event_id'] = i_evt
+        truth_data[x]['segment_id'] = waveforms_true_track_id[this_trig][i_op_channel][i_sample][i_content]
+        truth_data[x]['pe_current'] = waveforms_true_photons[this_trig][i_op_channel][i_sample][i_content]
+
     return truth_data
 
 def export_light_wvfm_to_hdf5(event_id, waveforms, output_filename, waveforms_true_track_id, waveforms_true_photons, i_trig, i_mod=-1, compression=None):

--- a/larndsim/light_sim.py
+++ b/larndsim/light_sim.py
@@ -655,12 +655,9 @@ def zero_suppress_waveform_truth(waveforms_true_track_id, waveforms_true_photons
         i_op_channel = j #idx1
         i_sample = k  #idx2
         i_content = l #idx3
-        truth_data[x]['trigger_id'] = i_trig
-        truth_data[x]['op_channel_id'] = op_channel[i_op_channel]
-        truth_data[x]['tick'] = i_sample
-        truth_data[x]['event_id'] = i_evt
-        truth_data[x]['segment_id'] = waveforms_true_track_id[this_trig][i_op_channel][i_sample][i_content]
-        truth_data[x]['pe_current'] = waveforms_true_photons[this_trig][i_op_channel][i_sample][i_content]
+        truth_data[x] = (i_trig, op_channel[i_op_channel], i_sample, i_evt,
+                         waveforms_true_track_id[this_trig][i_op_channel][i_sample][i_content],
+                         waveforms_true_photons[this_trig][i_op_channel][i_sample][i_content])
 
     return truth_data
 


### PR DESCRIPTION
Collection of commits for the performance improvements developed from the 2025 NERSC Open Hackathon results. Compared to commit 057d0911 from the develop branch, this achieves ~2.65x speed increase for a single 2x2 input file.

Summary of the changes include:
- Refactoring `zero_suppress_waveforms` to reduce memory accesses and reduce overhead of calculating array indices
- Precalculate sipm response for `calc_light_det_response()` and remove function call from GPU kernel
- Precalculate scintillation photons for `calc_scintillation_effect()` and remove function call from GPU kernel
- Madan's new `pixel_index_map` -- He completely rewrote it to drastically reduce the number of operations needed
- Registers per thread = 128 for `get_adc_values` -- part of the GPU kernel configuration, found by scanning and profiling each value

It also includes a new validation script for comparing two larnd-sim files (assuming deterministic runs)