### PR TITLE
Pre-trigger hits

### DIFF
--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -269,7 +269,7 @@ def export_to_hdf5(event_id_list,
                             continue
                 p.chip_key = chip_key
                 p.channel_id = channel
-                p.receipt_timestamp = time_tick
+                p.receipt_timestamp = time_tick + 20 * detector.CLOCK_CYCLE
                 p.packet_type = 0
                 p.first_packet = 1
                 p.assign_parity()
@@ -677,8 +677,7 @@ def get_adc_values(pixels_signals,
                 crossing_time_tick = min((ic, len(time_ticks)-1))
                 # handle case when tick extends past end of current array
                 post_adc_ticks = max((ic - crossing_time_tick, 0))
-                #+2-tick delay from when the PACMAN receives the trigger and when it registers it.
-                adc_ticks_list[ip][iadc] = time_ticks[crossing_time_tick]+time_padding-2+post_adc_ticks
+                adc_ticks_list[ip][iadc] = time_ticks[crossing_time_tick]+time_padding+post_adc_ticks
 
                 ic += round(detector.RESET_CYCLES * detector.CLOCK_CYCLE / detector.TIME_SAMPLING)
                 last_reset = ic

--- a/larndsim/fee.py
+++ b/larndsim/fee.py
@@ -269,7 +269,7 @@ def export_to_hdf5(event_id_list,
                             continue
                 p.chip_key = chip_key
                 p.channel_id = channel
-                p.receipt_timestamp = time_tick + 20 * detector.CLOCK_CYCLE
+                p.receipt_timestamp = time_tick
                 p.packet_type = 0
                 p.first_packet = 1
                 p.assign_parity()
@@ -677,7 +677,7 @@ def get_adc_values(pixels_signals,
                 crossing_time_tick = min((ic, len(time_ticks)-1))
                 # handle case when tick extends past end of current array
                 post_adc_ticks = max((ic - crossing_time_tick, 0))
-                adc_ticks_list[ip][iadc] = time_ticks[crossing_time_tick]+time_padding+post_adc_ticks
+                adc_ticks_list[ip][iadc] = time_ticks[crossing_time_tick]+time_padding+(post_adc_ticks*detector.TIME_SAMPLING)
 
                 ic += round(detector.RESET_CYCLES * detector.CLOCK_CYCLE / detector.TIME_SAMPLING)
                 last_reset = ic


### PR DESCRIPTION
Pre-trigger hits seem to be due to a PACMAN delay adjustment in: https://github.com/DUNE/larnd-sim/blob/3849e3f406734784c15f8860716a2e369a859542/larndsim/fee.py#L680-L681

The hit timestamp (in `adc_ticks_list`) should not be impacted by the transfer delay from the LArPix chip to the PACMAN, but rather the packet `receipt_timestamp`. Here I removed this delay from the `timestamp` to the `receipt_timestamp`.

A more correct implementation would calculate the delay in `receipt_timestamp` as a function of the depth of the chip in the hydra network, but I don't think this information is used in any downstream analyses on the simulation. 