### PR TITLE
Hotfix backtracking fix

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1191,6 +1191,9 @@ def run_simulation(input_filename,
                 
                 # Now directly map neighboring_pixels to pixel indices using lookup
                 pixel_index_map = pix_lookup[neighboring_pixels]
+                # Some elements of neighboring_pixels can have values of -1.
+                # We want to make sure these pixels are also removed in pixel_index_map.`
+                pixel_index_map[neighboring_pixels==-1] = -1
                 RangePop()
 
                 RangePush("track_pixel_map")

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1238,7 +1238,7 @@ def run_simulation(input_filename,
 
                 detsim.sum_pixel_signals[BPG,TPB](pixels_signals,
                                                   signals,
-                                                  cp.array(selected_tracks['t0']),
+                                                  cp.array(selected_tracks['t0']/detector.TIME_SAMPLING, dtype = int),
                                                   pixel_index_map,
                                                   track_pixel_map,
                                                   pixels_tracks_signals,

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -1223,7 +1223,7 @@ def run_simulation(input_filename,
                 # num_backtrack[ipix] is the number of segments contributing to the pixel
                 num_backtrack = cp.sum(track_pixel_map != -1, axis=-1)
                 # pixels_tracks_signals is a jagged array of conceptual dimension
-                # (#unique_pix, #ticks, backtracked_segments)
+                # (#ticks, #unique_pix, backtracked_segments)
                 # where the final axis (over segments) is jagged.
                 # Physically it's represented as a 1D array where the time index
                 # increments the slowest, followed by the pixel index, followed

--- a/larndsim/detsim.py
+++ b/larndsim/detsim.py
@@ -125,6 +125,7 @@ def tracks_current_mc(signals, pixels, tracks, response, rng_states):
     if itrk < signals.shape[0] and ipix < signals.shape[1] and it < signals.shape[2]:
         t = tracks[itrk]
         pID = pixels[itrk][ipix]
+        if pID < 0 : return
         pID_x, pID_y, pID_plane = id2pixel(pID)
 
         if pID_x >= 0 and pID_y >= 0:


### PR DESCRIPTION
This PR corrects the backtracking issues observed by Bruce Howard  in the initial MR6.5 spin. He observed that there were many hits without any backtracked segments. Here is the Slack [link](https://dunescience.slack.com/archives/C0496EJK59D/p1756154331847469) to his post, and I've attached his slide. 
[2x2_MiniRun_Comparison.pdf](https://github.com/user-attachments/files/22033838/2x2_MiniRun_Comparison.pdf)

The issue was traced first to bad `current_fractions` (Slack link [here](https://dunescience.slack.com/archives/C0496EJK59D/p1756272257800459)) and ultimately to `pixels_tracks_signals` ([here](https://github.com/DUNE/larnd-sim/blob/1ba10107de3192f020de5ec36e8c14a3668c25c9/cli/simulate_pixels.py#L1231)) being filled in incorrectly. 

This was tested by comparing `pixels_tracks_signals` and `pixels_signals`. `pixels_signals` (shape (#pixels, #ticks))gives the combined induced signal on each pixel. `pixels_tracks_signals` (a 1D array which can be conceptualized as a jagged array of shape (#ticks, #pixels, #segments), where #segments is the jagged component) gives the induced signal on each pixel from each segment. Therefore `pixels_tracks_signals` can be compared with `pixels_signals` to check if it is being filled in properly. 

[After](https://github.com/DUNE/larnd-sim/blob/1ba10107de3192f020de5ec36e8c14a3668c25c9/cli/simulate_pixels.py#L1239) `sum_pixel_signals`, I collapse `pixels_signals` and `pixels_tracks_signals` so that it gives me the total induced signal on each pixel and print that out (code pasted below for reference)
```python
                 print("pixel_signals\n", pixels_signals.sum(axis=-1))                                               
                                                                                                                     
                 a = pixels_tracks_signals.get()                                                                     
                 a = np.reshape(a, (signals_ticks_t0, int(num_backtrack.sum())))                                     
                 bt  = cp.append(offset_backtrack, [offset_backtrack[-1] + num_backtrack[-1]])                       
                 bt = bt.get()                                                                                       
                 a = [ a[:, bt[i]:bt[i+1]].sum(axis=-1) for i in range(len(bt)-1)]                                   
                 a = np.array(a)                                                                                     
                 print("\n pixels_tracks_signals\n", a.sum(axis=-1))
```
An example output is pasted below, showing inconsistencies. 
```
pixel_signals:
 [ 0.94027581 -3.17951654  0.72214372 ...  0.          0.
  0.        ]

 pixels_tracks_signals:
 [ -1.01580912  -9.14673328 -26.20556638 ...   0.40930901  -0.27295125
   0.34227214]
```

The issue comes from [this](https://github.com/DUNE/larnd-sim/blob/1ba10107de3192f020de5ec36e8c14a3668c25c9/cli/simulate_pixels.py#L1241) line, where the `t0` added back in is being passed in as 
`cp.array(selected_tracks['t0'])`
when it should be `cp.array(selected_tracks['t0']/detector.TIME_SAMPLING, dtype = int)`. When `pixels_tracks_signals` is being filled, the incorrect `track_t0` [here](https://github.com/DUNE/larnd-sim/blob/1ba10107de3192f020de5ec36e8c14a3668c25c9/larndsim/detsim.py#L258) will put the starting index in the wrong location. The wrong scale will shift the start of the signal down by a factor of 10, and non-integer `track_t0` will place `base_idx` in the middle of the conceptual (pixel, segment) sub-array, instead of the beginning. (I can go in more detail if someone would like).

 With the commits above, the output is now 
 ```
pixel_signals
 [ 0.94027581 -3.17951654  0.72214372 ...  0.          0.
  0.        ]

 pixels_tracks_signals
 [ 0.94027581 -3.17951654  0.72214372 ...  0.          0.
  0.        ]
``` 

