### PR TITLE
Restoring delayed segment t0 filter

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -306,8 +306,6 @@ def run_simulation(input_filename,
 
     print(LOGO)
     print("**************************\nLOADING SETTINGS AND INPUT\n**************************")
-    
-    
 
     if not os.path.exists(input_filename):
         raise Exception(f'Input file {input_filename} does not exist.')

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -306,6 +306,8 @@ def run_simulation(input_filename,
 
     print(LOGO)
     print("**************************\nLOADING SETTINGS AND INPUT\n**************************")
+    
+    
 
     if not os.path.exists(input_filename):
         raise Exception(f'Input file {input_filename} does not exist.')
@@ -591,6 +593,20 @@ def run_simulation(input_filename,
             tracks['t0_end'] = tracks['t0_end'] - localSpillIDs*sim.SPILL_PERIOD
             tracks['t0'] = tracks['t0'] - localSpillIDs*sim.SPILL_PERIOD
 
+        # Filter out neutrons and gammas, which will not directly create visible charge or light
+        # (excluding these segments here results in a modest ~10% improvement to memory usage later on,
+        # since this reduces the size of the arrays CUDA must inialize for pixel current calculations)
+        neutrals_mask = (tracks['pdg_id'] != 2112) & (tracks['pdg_id'] != 22)
+        if sum(~neutrals_mask) > 0: print("Rejected ",sum(~neutrals_mask), "track segments from neutral particles")
+        tracks = tracks[neutrals_mask]
+
+        # Filter out highly-delayed segments
+        t0_delay_mask = (tracks['t0'] < sim.MAX_SEGMENT_T0)
+        if sum(~t0_delay_mask) > 0:
+          print("Rejected ",sum(~t0_delay_mask)," highly-delayed segments with T0 > ",sim.MAX_SEGMENT_T0," us: ")
+          for val in tracks[~t0_delay_mask]: print(' t0 = ',val['t0'])
+        tracks = tracks[t0_delay_mask] 
+
         if 'segment_id' in tracks.dtype.names:
             segment_ids = tracks['segment_id']
             trajectory_ids = tracks['file_traj_id']
@@ -757,15 +773,7 @@ def run_simulation(input_filename,
     active_tracks = all_mod_tracks[active_tracks_mask]
     active_segment_ids = all_mod_segment_ids[active_tracks_mask]
     active_trajectory_ids = all_mod_trajectory_ids[active_tracks_mask]
-
-    t0_delay_mask = (active_tracks['t0'] < detector.SIGNAL_OVERLAP_CUT)
-    tracks = active_tracks[t0_delay_mask]
-    segment_ids = active_segment_ids[t0_delay_mask]
-    trajectory_ids = active_trajectory_ids[t0_delay_mask]
-    end_mask = time()
-    print(f"{len(all_mod_tracks) - len(active_tracks_mask)} segments are removed due to the active volume cut. \
-            In addition, {np.count_nonzero(~t0_delay_mask)} segments are removed due to the t0 delay cut.")
-    print(f" {end_mask-start_mask:.2f} s")
+    print(f"{len(all_mod_tracks) - len(active_tracks_mask)} segments are removed due to the active volume cut.")
 
     # We need to make cupy arrays of these and pass them to the kernels;
     # otherwise numba will try to use the GPU's "global constant" memory

--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -133,9 +133,6 @@ DISCRIMINATOR_NOISE = 650 # e
 EVENT_RATE = 100000 # 10Hz
 #: Offset of the non-beam event time in microseconds
 NON_BEAM_EVENT_GAP = 0 # us
-#: T0 delay cut 
-#: The assumption is the late signals are small, and if they don't overlap with the main, they are not considered
-SIGNAL_OVERLAP_CUT = 30 # us --> NOTE: this is now controlled by sim.MAX_SEGMENT_T0
 #: Pad the signal range to allow N sigmas of diffusion
 DIFF_N_SIGMAS = 5
 #: Distances of the neighboring pixels to the center pixel
@@ -263,7 +260,6 @@ def set_detector_properties(detprop_file, pixel_file, response_file=None, i_modu
     global DISCRIMINATOR_NOISE
     global EVENT_RATE
     global NON_BEAM_EVENT_GAP
-    global SIGNAL_OVERLAP_CUT
     global DIFF_N_SIGMAS
     global NEIGHBORING_PIX_DIST
 
@@ -357,7 +353,6 @@ def set_detector_properties(detprop_file, pixel_file, response_file=None, i_modu
     MODULE_TO_TPCS = detprop['module_to_tpcs']
     TPC_TO_MODULE = dict([(tpc, mod) for mod,tpcs in MODULE_TO_TPCS.items() for tpc in tpcs])
 
-    SIGNAL_OVERLAP_CUT = detprop.get('signal_overlap_cut', SIGNAL_OVERLAP_CUT)
     DIFF_N_SIGMAS = detprop.get('signal_overlap_cut', DIFF_N_SIGMAS)
 
     if not geo_only:

--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -135,7 +135,7 @@ EVENT_RATE = 100000 # 10Hz
 NON_BEAM_EVENT_GAP = 0 # us
 #: T0 delay cut 
 #: The assumption is the late signals are small, and if they don't overlap with the main, they are not considered
-SIGNAL_OVERLAP_CUT = 30 # us
+SIGNAL_OVERLAP_CUT = 30 # us --> NOTE: this is now controlled by sim.MAX_SEGMENT_T0
 #: Pad the signal range to allow N sigmas of diffusion
 DIFF_N_SIGMAS = 5
 #: Distances of the neighboring pixels to the center pixel

--- a/larndsim/consts/sim.py
+++ b/larndsim/consts/sim.py
@@ -14,6 +14,9 @@ EVENT_BATCH_SIZE = 1  # units = N tpcs
 WRITE_BATCH_SIZE = 1  # units = N batches
 EVENT_SEPARATOR = 'event_id'  # 'spillID' or 'vertexID'
 
+# Filter out highly-delayed track segments
+MAX_SEGMENT_T0 = 30 # microseconds
+
 IS_SPILL_SIM = True
 SPILL_PERIOD = 1.2e6  # units = microseconds
 TRACKS_DSET_NAME = 'segments'
@@ -50,6 +53,7 @@ def set_simulation_properties(simprop_file):
     global EVENT_BATCH_SIZE
     global WRITE_BATCH_SIZE
     global EVENT_SEPARATOR
+    global MAX_SEGMENT_T0
     global IS_SPILL_SIM
     global SPILL_PERIOD
     global MAX_EVENTS_PER_FILE
@@ -72,6 +76,7 @@ def set_simulation_properties(simprop_file):
         EVENT_BATCH_SIZE = simprop.get('event_batch_size', EVENT_BATCH_SIZE)
         WRITE_BATCH_SIZE = simprop.get('write_batch_size', WRITE_BATCH_SIZE)
         EVENT_SEPARATOR = simprop.get('event_separator', EVENT_SEPARATOR)
+        MAX_SEGMENT_T0 = simprop.get('max_segment_t0', MAX_SEGMENT_T0)
         IS_SPILL_SIM = bool(simprop.get('is_spill_sim', IS_SPILL_SIM))
         SPILL_PERIOD = float(simprop.get('spill_period', SPILL_PERIOD))
         MAX_EVENTS_PER_FILE = simprop.get('max_events_per_file', MAX_EVENTS_PER_FILE)


### PR DESCRIPTION
While investigating catastrophic memory failures in MiniRun6.5 jobs, where CUDA is asked to allocate O(TBs) resulting in the job crashing, I discovered that this was due to segments with highly-delayed `t0` no longer getting removed like they were in tag v0.4.2. It looks like this code was re-arranged slightly since that tag. This PR moves the delayed t0 filter back to where it was before, filtering out the segments as early as possible in the code before any subsets or copies of the `tracks` array can be created. With the change in place, these memory crashes no longer occur.

I found that the 'detector' properties parameter `SIGNAL_OVERLAP_CUT` couldn't be accessed in this part of the code, so I made a new parameter `MAX_SEGMENT_T0` to `consts/sim.py` to control this filter instead. It is set to the same value of 30 microseconds.

It also adds a filter removing segments from neutral particles as well (neutrons and gammas) since they will not produce ionization signals. This reduces the peak memory slightly by 5-10%.