### PR TITLE
Modernize package metadata with pyproject.toml

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -41,8 +41,6 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install pytest
-          if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
-
           pip install --editable .
 
       # Runs a set of commands using the runners shell

--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -22,17 +22,6 @@ if os.getenv('LARNDSIM_DISABLE_CUPY_MEMPOOL'):
     # Disable memory pool for pinned memory (CPU):
     cp.cuda.set_pinned_memory_allocator(None)
 
-# Perlmutter GPU driver corresponds to CUDA 12.2
-if os.getenv('LMOD_SYSTEM_NAME') == 'perlmutter':
-    try:
-        cuda_dir = os.path.basename(os.environ['CUDA_HOME'])
-        cuda_ver = float(cuda_dir)
-        if cuda_ver >= 12.3:
-            import pynvjitlink.patch
-            pynvjitlink.patch.patch_numba_linker()
-    except:
-        pass
-
 import fire
 import h5py
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,50 @@
+[build-system]
+requires = ["setuptools>=64.0.0", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "larndsim"
+version = "0.4.2"
+description = "Simulation framework for the DUNE LArND"
+authors = [
+    { name = "DUNE collaboration" }
+]
+maintainers = [
+    { name = "Jaafar Chakrani" },
+    { name = "Yifan Chen" },
+    { name = "Matt Kramer" },
+    { name = "Kevin Wood" },
+]
+readme = "README.md"
+requires-python = ">=3.7"
+license = { text = "Apache-2.0" }
+
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "Operating System :: OS Independent",
+    "Programming Language :: Python",
+    "Topic :: Scientific/Engineering :: Physics"
+]
+
+dynamic = ["dependencies", "optional-dependencies"]
+
+[project.urls]
+Homepage = "https://github.com/DUNE/larnd-sim"
+Repository = "https://github.com/DUNE/larnd-sim"
+
+[tool.setuptools]
+packages = ["larndsim"]
+include-package-data = true
+script-files = ["cli/simulate_pixels.py", "cli/dumpTree.py", "cli/list_config_keys.py"]
+
+[tool.setuptools.package-data]
+larndsim = [
+    "config/*.yaml",
+    "simulation_properties/*.yaml",
+    "pixel_layouts/*.yaml",
+    "detector_properties/*.yaml",
+    "detector_properties/*.json",
+    "bin/*.npy",
+    "bin/*.npz",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-numpy
-pytest~=6.2
-numba
-sphinx-rtd-theme~=0.5
-tqdm
-fire
-larpix-control
-larpix-geometry

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
-#!/usr/bin/env python
+from setuptools import setup
+import os
 
-VER = "0.3.1"
-
-reqs = ["numpy", "pytest", "numba>=0.52", "larpix-control", "larpix-geometry", "tqdm", "fire", "nvidia-ml-py"]
+dependencies = [
+    "numpy",
+    "pytest",
+    "numba>=0.52",
+    "larpix-control",
+    "larpix-geometry",
+    "tqdm",
+    "fire",
+    "nvidia-ml-py",
+]
 
 try:
     import cupy
@@ -15,57 +23,32 @@ try:
     '''
     print(msg % (str(cupy.__version__),str(cupy.__file__)))
 except ImportError:
-    reqs.append('cupy')
+    dependencies.append('cupy')
 
-import os
 try:
     cuda_dir = os.path.basename(os.environ['CUDA_HOME'])
     cuda_ver = float(cuda_dir)
     cuda_major_ver = int(cuda_ver)
+    print(f"larnd-sim -- Found CUDA version: {cuda_ver}")
 except:
     cuda_ver = cuda_major_ver = -1
 
-if 'cupy' in reqs:
+if 'cupy' in dependencies:
     if 'SKIP_CUPY_INSTALL' in os.environ:
-        reqs.remove('cupy')
+        dependencies.remove('cupy')
     else:
         if 'ALWAYS_COMPILE_CUPY' not in os.environ:
             if cuda_major_ver in [11, 12]:
-                reqs.remove('cupy')
-                reqs.append(f'cupy-cuda{cuda_major_ver}x')
+                dependencies.remove('cupy')
+                dependencies.append(f'cupy-cuda{cuda_major_ver}x')
 
-import setuptools
-
-setuptools.setup(
-    name="larndsim",
-    version=VER,
-    author="DUNE collaboration",
-    author_email="roberto@lbl.gov",
-    description="Simulation framework for the DUNE LArND",
-    url="https://github.com/DUNE/larnd-sim",
-    packages=setuptools.find_packages(),
-    include_package_data=True,
-    package_data={'larndsim': ['config/*.yaml',
-    'simulation_properties/*.yaml',
-    'pixel_layouts/*.yaml',
-    'detector_properties/*.yaml',
-    'detector_properties/*.json',
-    'bin/*.npy',
-    'bin/*.npz',
-    ]},
-    scripts=["cli/simulate_pixels.py", "cli/dumpTree.py", "cli/list_config_keys.py"],
-    install_requires=reqs,
-    classifiers=[
-        "Development Status :: 2 - Pre-Alpha",
-        "Intended Audience :: by End-User Class :: Developers",
-        "Operating System :: Grouping and Descriptive Categories :: OS Independent (Written in an interpreted language)",
-        "Programming Language :: Python",
-        "Topic :: Scientific/Engineering :: Physics"
-    ],
-    python_requires='>=3.7',
-)
-
-if os.getenv('LMOD_SYSTEM_NAME') == 'perlmutter':
+if os.environ['LMOD_SYSTEM_NAME'] == 'perlmutter':
     # Revisit this after Perlmutter driver update (currently 525.105.17)
     if cuda_ver >= 12.3 and 'SKIP_PYNVJITLINK_INSTALL' not in os.environ:
-        os.system('pip install --extra-index-url https://pypi.nvidia.com pynvjitlink-cu12')
+        print(f"Installing pynvjitlink-cu12")
+        os.environ['PIP_EXTRA_INDEX_URL'] = 'https://pypi.nvidia.com'
+        dependencies.append('pynvjitlink-cu12')
+
+setup(
+    install_requires=dependencies,
+)

--- a/setup.py
+++ b/setup.py
@@ -42,13 +42,6 @@ if 'cupy' in dependencies:
                 dependencies.remove('cupy')
                 dependencies.append(f'cupy-cuda{cuda_major_ver}x')
 
-if os.environ['LMOD_SYSTEM_NAME'] == 'perlmutter':
-    # Revisit this after Perlmutter driver update (currently 525.105.17)
-    if cuda_ver >= 12.3 and 'SKIP_PYNVJITLINK_INSTALL' not in os.environ:
-        print(f"Installing pynvjitlink-cu12")
-        os.environ['PIP_EXTRA_INDEX_URL'] = 'https://pypi.nvidia.com'
-        dependencies.append('pynvjitlink-cu12')
-
 setup(
     install_requires=dependencies,
 )


### PR DESCRIPTION
Fix a deprecation warning regarding the legacy install method by updating the package metadata and build specification (e.g. dependencies) to use `pyproject.toml` with a `setup.py` for building a dynamic dependency list.

Basically `pyproject.toml` contains most of the info, and `setup.py` is used to dynamically inspect the user's environment to install the correct version of CuPy based on the active CUDA version.

Also updated some of the metadata, such as the version, authors, and maintainers.

Let me know or edit the `pyproject.toml` to further update the package metadata. Since this is messing with the installation method, it should be tested by at least one other person.