### PR TITLE
Have MC tile layout match data

### DIFF
--- a/larndsim/config/config.yaml
+++ b/larndsim/config/config.yaml
@@ -89,7 +89,7 @@ ndlar_light:
 
 fsd:
     SIM_PROPERTIES:  cosmic_sim.yaml
-    PIXEL_LAYOUT:    multi_tile_layout-3.0.40_NDLArModule_v3.yaml
+    PIXEL_LAYOUT:    multi_tile_layout-3.0.40_fsd_v3.yaml
     DET_PROPERTIES:  fsd.yaml
     RESPONSE:        response_37_v2d_fsd_ndlar_full.npz
     PIXEL_THRESHOLDS_FILE: thresholds_fsd.npz

--- a/larndsim/detector_properties/fsd.yaml
+++ b/larndsim/detector_properties/fsd.yaml
@@ -9,8 +9,8 @@ tpc_offsets: # cm
 # as in nd-lar (also in fsd) one vertical row of tiles are connected to one pacman (one io-group)
 # while in 2x2 modules, the tile numbering follows horizontal first and then vertical in the 2x4 anode.
 tile_map:
-  - [[10,9,8,7,6,5,4,3,2,1],[20,19,18,17,16,15,14,13,12,11]]
-  - [[30,29,28,27,26,25,24,23,22,21],[40,39,38,37,36,35,34,33,32,31]]
+  - [[20,19,18,17,16,15,14,13,12,11],[10,9,8,7,6,5,4,3,2,1]]
+  - [[40,39,38,37,36,35,34,33,32,31],[30,29,28,27,26,25,24,23,22,21]]
 module_to_io_groups:
   1: [1, 2, 3, 4]
 


### PR DESCRIPTION
This PR reconfigures the charge layout so that the simulation matches the data. I'll refer to the comment in the linked [PR](https://github.com/DUNE/ndlar_flow/pull/212) as validation for this PR. 
This PR should be merged in conjunction with the linked PR. 