### PR TITLE
Have LUT be read bottom-up, and modify the 2x2 LUTs to match true geometry

### DIFF
--- a/larndsim/config/config.yaml
+++ b/larndsim/config/config.yaml
@@ -7,7 +7,7 @@ module0:
     # Path to light LUT at NERSC
     # Web portal: https://portal.nersc.gov/project/dune/data/2x2/simulation/larndsim_data/light_LUT/
     # Alternatively low granularity Mod0 based light LUT in larndsim, lightLUT.npz
-    LIGHT_LUT:       /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024_time_norm.npz
+    LIGHT_LUT:       /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024_time_norm_swapped_y.npz
     LIGHT_DET_NOISE: light_noise-module0.npy
     LIGHT_SIMULATED: True
 
@@ -20,7 +20,7 @@ module0:
     # Path to light LUT at NERSC
     # Web portal: https://portal.nersc.gov/project/dune/data/2x2/simulation/larndsim_data/light_LUT/
     # Alternatively low granularity Mod0 based light LUT in larndsim, lightLUT.npz
-    LIGHT_LUT:       /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024_time_norm.npz
+    LIGHT_LUT:       /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024_time_norm_swapped_y.npz
     LIGHT_DET_NOISE: 4Mod_LNoise_Mod1_2fftx192_MR5-ish.npy
     LIGHT_SIMULATED: True
     MOD2MOD_VARIATION: False
@@ -53,7 +53,7 @@ module0:
     # Web portal: https://portal.nersc.gov/project/dune/data/2x2/simulation/larndsim_data/light_LUT/
     # Alternatively low granularity Mod0 based light LUT in larndsim, lightLUT.npz
     # LIGHT_LUT:       [/sdf/data/neutrino/2x2/light_lut/lightLUT_Mod0_06052024_time_norm.npz, /sdf/data/neutrino/2x2/light_lut/lightLUT_Mod123_06052024_time_norm.npz]
-    LIGHT_LUT:       [/dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024_time_norm.npz, /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024_time_norm.npz]
+    LIGHT_LUT:       [/dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024_time_norm_swapped_y.npz, /dvs_ro/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024_time_norm_swapped_y.npz]
     LIGHT_LUT_ID:    [0, 1, 1, 1]
     MOD2MOD_VARIATION: True
 

--- a/larndsim/lightLUT.py
+++ b/larndsim/lightLUT.py
@@ -53,7 +53,7 @@ def get_voxel(pos, itpc, lut_vox_div):
         # rather than the xMin side as means of rotating the x component
         i = int((x_max - pos[0])/(x_max - x_min) * lut_vox_div[0])
 
-    j = int((y_max - pos[1])/(y_max - y_min) * lut_vox_div[1])
+    j = int((pos[1] - y_min)/(y_max - y_min) * lut_vox_div[1])
     k = int((pos[2] - z_min)/(z_max - z_min) * lut_vox_div[2])
 
     i = min(lut_vox_div[0] - 1, max(0, i))


### PR DESCRIPTION
As title says.
EDIT: [Here](https://docs.dunescience.org/cgi-bin/sso/RetrieveFile?docid=35172&filename=20251104-LUTissues.pdf&version=1)'s the talk where I went over the issues seen. If anyone missed it and would like a more detailed explanation, let me know and we can chat. 
EDIT: I'm adding everyone think might have any familiarity with the LUTs. No need to actually review if this isn't within your purview. 
To reflect the y-axis in the LUT, I used the following code:

```python
import numpy as np

def swap_y(filename, outfile):
    data = np.load(filename)['arr']
    arr = data.copy()
    arr = arr [:, ::-1, :, :]
    n_op_chan = arr.shape[-1]
    arr[..., :n_op_chan//2] = arr[..., :n_op_chan//2][...,::-1]
    arr[..., n_op_chan//2:] = arr[..., n_op_chan//2:][...,::-1]
    np.savez_compressed(outfile, arr=arr)
    return

filename = "/global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod0_06052024_time_norm.npz"
outfile = filename.replace(".npz", "_swapped_y.npz")
swap_y(filename, outfile)

filename = "/global/cfs/cdirs/dune/www/data/2x2/simulation/larndsim_data/light_LUT/lightLUT_Mod123_06052024_time_norm.npz"
outfile = filename.replace(".npz", "_swapped_y.npz")
swap_y(filename, outfile)

```

Flipping for FSD shouldn't be necessary. 
The optical channel mapping will have to be remapped in flow. 

