### PR TITLE
NDLAr Config Choices for MiniProdN5 Nominal (Sample A)

### DIFF
--- a/larndsim/detector_properties/ndlar-module.yaml
+++ b/larndsim/detector_properties/ndlar-module.yaml
@@ -128,4 +128,4 @@ light_digit_sample_spacing: 0.016 # us
 light_nbit: 14
 sipm_response_model: 1 # 0: RLC model; 1: measured
 impulse_model: 'larndsim/bin/sipm_impulse.npy'
-max_radius: 1
+max_radius: 4

--- a/larndsim/simulation_properties/NDLAr_LBNF_sim.yaml
+++ b/larndsim/simulation_properties/NDLAr_LBNF_sim.yaml
@@ -8,3 +8,6 @@ spill_period: 1.2e6          # microseconds
 event_separator: 'event_id'  # 'event_id'
 tracks_dset_name: 'segments' # or 'segments'
 max_events_per_file: 1000
+
+max_light_truth_ids: 50 # set to zero to disable light truth backtracking
+mc_truth_threshold: 0.1 # pe/us


### PR DESCRIPTION
Changing the `max_radius` to 4 and switching on light backtracking for NDLAr.