### PR TITLE
Option to use segments directly instead of voxels for far-field calculation

### DIFF
--- a/cli/simulate_pixels.py
+++ b/cli/simulate_pixels.py
@@ -174,7 +174,8 @@ def run_simulation(input_filename,
                    rand_seed=None,
                    compression=None,
                    save_memory=None,
-                   farfield_enabled=False):
+                   farfield_enabled=False,
+                   farfield_mode='segments'):
     """
     Command-line interface to run the simulation of a pixelated LArTPC
 
@@ -209,6 +210,7 @@ def run_simulation(input_filename,
             store memory snapshot information
         compression (str, optional): enable file compression of the output HDF5 datasets. Defaults to None,
             supported options are 'lzf' and 'gzip'
+        farfield_mode (str, optional): far-field method, either 'segments' or 'voxels'.
     """
     # Define a nested function to save the results
     def save_results(event_times, results, i_trig, i_mod=-1, light_only=False):
@@ -420,6 +422,12 @@ def run_simulation(input_filename,
         print('Recording the process resource log:', save_memory)
     else:
         print('Memory resource log will not be recorded')
+
+    farfield_mode = str(farfield_mode).lower()
+    if farfield_mode not in ('segments', 'voxels'):
+        raise ValueError(f"Unsupported farfield_mode='{farfield_mode}'. Use 'segments' or 'voxels'.")
+    if farfield_enabled:
+        print("Far-field mode:", farfield_mode)
 
     # Get number of modules in the simulation
     mod_ids = consts.detector.get_n_modules(detector_properties)
@@ -1103,41 +1111,43 @@ def run_simulation(input_filename,
             assmap_pix2seg = invert_array_map(all_neighboring_pixels,all_unique_pix)
             RangePop() # invert_array_map
 
-            # ~~~ Voxelize per-TPC once per event batch to avoid cross-TPC contamination ~~~
-            RangePush("event_voxelization")
+            # ~~~ Precompute far-field helper data once per event batch ~~~
+            RangePush("event_farfield_precompute")
             voxel_cache = {}
-            classification_cache = {}
             voxel_radius = None
+            classification_cache = {}
             active_tpc_indices_all = np.unique(all_selected_tracks['pixel_plane'].astype(np.int32)) if farfield_enabled else []
             if farfield_enabled:
-                voxel_radius = np.sqrt(
-                    (mesh_params.COARSE_VOXEL_SIZE_X / 2.0)**2 + 
-                    (mesh_params.COARSE_VOXEL_SIZE_Y / 2.0)**2 + 
-                    (mesh_params.COARSE_VOXEL_SIZE_Z / 2.0)**2
-                )
                 all_tracks_cpu = cp.asnumpy(all_selected_tracks)
                 for tpc_idx in active_tpc_indices_all:
-                    tpc_tracks = all_selected_tracks[all_selected_tracks['pixel_plane'] == tpc_idx]
-                    if len(tpc_tracks) == 0:
-                        voxel_cache[int(tpc_idx)] = {"x": None, "y": None, "z": None, "q": None}
-                        classification_cache[int(tpc_idx)] = None
-                        continue
-                    voxel_indices, voxel_charges, grid_shape, voxel_size, bounds = voxelization.gpu_voxelize(
-                        tpc_tracks, tpc_borders=detector.TPC_BORDERS[[tpc_idx]]
-                    )
-                    if len(voxel_indices) > 0:
-                        vx, vy, vz = voxelization.voxel_id_to_coordinates(voxel_indices, grid_shape, voxel_size, bounds)
-                        voxel_cache[int(tpc_idx)] = {
-                            "x": cp.asarray(vx, dtype=cp.float32),
-                            "y": cp.asarray(vy, dtype=cp.float32),
-                            "z": cp.asarray(vz, dtype=cp.float32),
-                            "q": cp.asarray(voxel_charges, dtype=cp.float32),
-                        }
-                    else:
-                        voxel_cache[int(tpc_idx)] = {"x": None, "y": None, "z": None, "q": None}
-
                     # Precompute pixel classification per TPC (for induction-only masks)
                     classification_cache[int(tpc_idx)] = pixel_classifier.classify_pixels(all_tracks_cpu, plane_id=int(tpc_idx))
+
+                if farfield_mode == 'voxels':
+                    voxel_radius = np.sqrt(
+                        (mesh_params.COARSE_VOXEL_SIZE_X / 2.0)**2 +
+                        (mesh_params.COARSE_VOXEL_SIZE_Y / 2.0)**2 +
+                        (mesh_params.COARSE_VOXEL_SIZE_Z / 2.0)**2
+                    )
+                    for tpc_idx in active_tpc_indices_all:
+                        tpc_tracks = all_selected_tracks[all_selected_tracks['pixel_plane'] == tpc_idx]
+                        if len(tpc_tracks) == 0:
+                            voxel_cache[int(tpc_idx)] = {"x": None, "y": None, "z": None, "q": None}
+                            continue
+
+                        voxel_indices, voxel_charges, grid_shape, voxel_size, bounds = voxelization.gpu_voxelize(
+                            tpc_tracks, tpc_borders=detector.TPC_BORDERS[[tpc_idx]]
+                        )
+                        if len(voxel_indices) > 0:
+                            vx, vy, vz = voxelization.voxel_id_to_coordinates(voxel_indices, grid_shape, voxel_size, bounds)
+                            voxel_cache[int(tpc_idx)] = {
+                                "x": cp.asarray(vx, dtype=cp.float32),
+                                "y": cp.asarray(vy, dtype=cp.float32),
+                                "z": cp.asarray(vz, dtype=cp.float32),
+                                "q": cp.asarray(voxel_charges, dtype=cp.float32),
+                            }
+                        else:
+                            voxel_cache[int(tpc_idx)] = {"x": None, "y": None, "z": None, "q": None}
             RangePop()
 
             pixel_ranges = batching.subbatch_pixel_ranges(assmap_pix2seg,
@@ -1323,78 +1333,81 @@ def run_simulation(input_filename,
                 # ~~~ Far-field signal contribution ~~~
                 if farfield_enabled:
                     RangePush("far_field_contribution", 3)
-                    # print("Calculating far-field contribution...", end="")
-                    if voxel_cache and any(v["x"] is not None for v in voxel_cache.values()):
-                        # Get pixel coordinates from pixel layout
-                        # unique_pix contains pixel indices; convert to (x, y) coordinates
-                        # Decode pixel IDs: px = id % N_PIXELS[0], py = (id // N_PIXELS[0]) % N_PIXELS[1]
-                        unique_pix_np = cp.asnumpy(unique_pix)
-                        px_idx = unique_pix_np % detector.N_PIXELS[0]
-                        py_idx = (unique_pix_np // detector.N_PIXELS[0]) % detector.N_PIXELS[1]
-                        plane_idx = unique_pix_np // (detector.N_PIXELS[0] * detector.N_PIXELS[1])
-                        # Get x_min and y_min for each pixel's TPC (vectorized)
-                        x_min = detector.TPC_BORDERS[plane_idx.astype(int), 0, 0]
-                        y_min = detector.TPC_BORDERS[plane_idx.astype(int), 1, 0]
-                        pixel_x = cp.asarray(x_min + (px_idx + 0.5) * detector.PIXEL_PITCH, dtype=cp.float32)
-                        pixel_y = cp.asarray(y_min + (py_idx + 0.5) * detector.PIXEL_PITCH, dtype=cp.float32)
-                        
-                        # Pixel categories: treat as neighbor/collection (exclusion radius applied uniformly)
-                        pixel_categories = cp.ones(len(unique_pix), dtype=cp.int32)
-                        
-                        # Exclusion radius for boundary weighting
-                        exclude_radius = mesh_params.CHARGE_NEIGHBOR_RADIUS * detector.PIXEL_PITCH
+                    # Get pixel coordinates from pixel layout
+                    # unique_pix contains pixel indices; convert to (x, y) coordinates
+                    unique_pix_np = cp.asnumpy(unique_pix)
+                    px_idx = unique_pix_np % detector.N_PIXELS[0]
+                    py_idx = (unique_pix_np // detector.N_PIXELS[0]) % detector.N_PIXELS[1]
+                    plane_idx = unique_pix_np // (detector.N_PIXELS[0] * detector.N_PIXELS[1])
+                    x_min = detector.TPC_BORDERS[plane_idx.astype(int), 0, 0]
+                    y_min = detector.TPC_BORDERS[plane_idx.astype(int), 1, 0]
+                    pixel_x = cp.asarray(x_min + (px_idx + 0.5) * detector.PIXEL_PITCH, dtype=cp.float32)
+                    pixel_y = cp.asarray(y_min + (py_idx + 0.5) * detector.PIXEL_PITCH, dtype=cp.float32)
 
-                        # Extract active TPCs from all_selected_tracks (event batch) not selected_tracks (pixel batch subset)
-                        # This ensures we loop over all TPCs that have voxels, not just TPCs with pixels in this batch
-                        active_tpc_indices = np.unique(all_selected_tracks['pixel_plane'].astype(np.int32))
+                    exclude_radius = mesh_params.CHARGE_NEIGHBOR_RADIUS * detector.PIXEL_PITCH
+                    split_step_cm = mesh_params.FAR_FIELD_SEGMENT_STEP_CM
+                    active_tpc_indices = np.unique(all_selected_tracks['pixel_plane'].astype(np.int32))
 
-                        for tpc_idx in active_tpc_indices:
-                            tpc_idx = int(tpc_idx)
+                    for tpc_idx in active_tpc_indices:
+                        tpc_idx = int(tpc_idx)
+                        z_anode = float(detector.TPC_BORDERS[tpc_idx, 2, 0])
+                        z_cathode = float(detector.TPC_BORDERS[tpc_idx, 2, 1])
+
+                        tpc_mask = (plane_idx == tpc_idx)
+                        if not np.any(tpc_mask):
+                            continue
+                        pix_x_tpc = pixel_x[tpc_mask]
+                        pix_y_tpc = pixel_y[tpc_mask]
+                        n_pix_tpc = pix_x_tpc.shape[0]
+
+                        ff_signals_tpc = cp.zeros((n_pix_tpc, signals_ticks_t0), dtype=cp.float32)
+                        TPB_ff_tpc = (16, 16)
+                        BPG_ff_tpc = (ceil(n_pix_tpc / TPB_ff_tpc[0]), ceil(signals_ticks_t0 / TPB_ff_tpc[1]))
+
+                        if farfield_mode == 'voxels':
                             cache = voxel_cache.get(tpc_idx, None)
                             if cache is None or cache["x"] is None:
                                 continue
-                            z_anode = float(detector.TPC_BORDERS[tpc_idx, 2, 0])
-                            z_cathode = float(detector.TPC_BORDERS[tpc_idx, 2, 1])
-                            vx = cache["x"]
-                            vy = cache["y"]
-                            vz = cache["z"]
-                            vq = cache["q"]
-
-                            # Filter pixels belonging to this TPC only
-                            tpc_mask = (plane_idx == tpc_idx)
-                            if not np.any(tpc_mask):
-                                continue
-                            pix_x_tpc = pixel_x[tpc_mask]
-                            pix_y_tpc = pixel_y[tpc_mask]
-                            pix_cat_tpc = pixel_categories[tpc_mask]
-                            n_pix_tpc = pix_x_tpc.shape[0]
-
-                            # Allocate per-TPC FF signal buffer
-                            ff_signals_tpc = cp.zeros((n_pix_tpc, signals_ticks_t0), dtype=cp.float32)
-                            TPB_ff_tpc = (16, 16)
-                            BPG_ff_tpc = (ceil(n_pix_tpc / TPB_ff_tpc[0]), ceil(signals_ticks_t0 / TPB_ff_tpc[1]))
-
-                            # Calculate far-field for this TPC (writes to ff_signals_tpc)
+                            pixel_categories = cp.ones(n_pix_tpc, dtype=cp.int32)
                             signal_calculation.calculate_far_field_dipole_signal_time_kernel[BPG_ff_tpc, TPB_ff_tpc](
-                                vx, vy, vz,
-                                vq,
+                                cache["x"], cache["y"], cache["z"],
+                                cache["q"],
                                 pix_x_tpc, pix_y_tpc,
-                                pix_cat_tpc,
+                                pixel_categories,
                                 exclude_radius,
                                 voxel_radius,
                                 z_anode,
                                 z_cathode,
                                 detector.V_DRIFT,
                                 detector.TIME_SAMPLING,
-                                5,  # n_terms for series expansion
+                                5,
                                 mesh_params.INDUCED_CURRENT_SCALE,
                                 ff_signals_tpc
                             )
-                            
-                            # Accumulate to pixels_signals (broadcast to correct rows via tpc_mask)
-                            pixels_signals[tpc_mask, :] += ff_signals_tpc
+                        else:
+                            tpc_tracks = all_selected_tracks[all_selected_tracks['pixel_plane'] == tpc_idx]
+                            if len(tpc_tracks) == 0:
+                                continue
+                            signal_calculation.calculate_far_field_segment_signal_time_kernel[BPG_ff_tpc, TPB_ff_tpc](
+                                tpc_tracks,
+                                pix_x_tpc, pix_y_tpc,
+                                float(exclude_radius),
+                                float(split_step_cm),
+                                z_anode,
+                                z_cathode,
+                                detector.V_DRIFT,
+                                detector.TIME_SAMPLING,
+                                1,
+                                mesh_params.INDUCED_CURRENT_SCALE,
+                                ff_signals_tpc
+                            )
+
+                        pixels_signals[tpc_mask, :] += ff_signals_tpc
                         
                     RangePop()
+                
+                # np.savez(f'sig_{ievd}_{start_pix}_nf.npz', signals=pixels_signals, pixels=unique_pix)
+
                 RangePush("get_adc_values", 3)
                 # Here we simulate the electronics response (the self-triggering cycle) and the signal digitization
                 time_ticks = cp.arange(0, len(unique_eventIDs) * max_signal_time, detector.TIME_SAMPLING)
@@ -1460,16 +1473,15 @@ def run_simulation(input_filename,
                 results_acc['track_pixel_map'].append(track_pixel_map)
 
             # ~~~ Far-field-only induction pixels (not processed above) ~~~
-            if farfield_enabled and voxel_cache and any(v["x"] is not None for v in voxel_cache.values()):
+            if farfield_enabled:
                 RangePush("far_field_induction_only", 2)
                 # Pixels already processed via near-field path
                 processed_pixels = processed_pixels_event
                 # Unique TPCs in this batch (use all_selected_tracks to capture full event batch)
                 active_tpc_indices_all = np.unique(all_selected_tracks['pixel_plane'].astype(np.int32))
                 for tpc_idx in active_tpc_indices_all:
-                    cache = voxel_cache.get(int(tpc_idx), None)
                     cls = classification_cache.get(int(tpc_idx), None)
-                    if cache is None or cache["x"] is None or cls is None or len(cls.induction_pixels) == 0:
+                    if cls is None or len(cls.induction_pixels) == 0:
                         continue
                     # Induction-only pixels for this TPC; preserve ID/coordinate ordering
                     induction_pix_all = cp.asarray(cls.induction_pixels, dtype=cp.int32)
@@ -1491,7 +1503,6 @@ def run_simulation(input_filename,
 
                     if induction_pix_ids.size == 0:
                         continue
-                    pixel_categories_ff = cp.zeros(len(induction_pix_ids), dtype=cp.int32)  # category 0 = INDUCTION
 
                     # Use event-wide t0 max for tick extension (far-field only)
                     t0_array = cp.asnumpy(all_selected_tracks['t0'])
@@ -1504,26 +1515,43 @@ def run_simulation(input_filename,
                     z_anode = float(detector.TPC_BORDERS[tpc_idx, 2, 0])
                     z_cathode = float(detector.TPC_BORDERS[tpc_idx, 2, 1])
 
-                    vx = cache["x"]
-                    vy = cache["y"]
-                    vz = cache["z"]
-                    vq = cache["q"]
-
-                    signal_calculation.calculate_far_field_dipole_signal_time_kernel[BPG_ff, TPB_ff](
-                        vx, vy, vz,
-                        vq,
-                        pixel_x_ff, pixel_y_ff,
-                        pixel_categories_ff,
-                        mesh_params.CHARGE_NEIGHBOR_RADIUS * detector.PIXEL_PITCH,
-                        voxel_radius,
-                        z_anode,
-                        z_cathode,
-                        detector.V_DRIFT,
-                        detector.TIME_SAMPLING,
-                        5,
-                        mesh_params.INDUCED_CURRENT_SCALE,
-                        ff_signals
-                    )
+                    if farfield_mode == 'voxels':
+                        cache = voxel_cache.get(int(tpc_idx), None)
+                        if cache is None or cache["x"] is None:
+                            continue
+                        pixel_categories_ff = cp.zeros(len(induction_pix_ids), dtype=cp.int32)
+                        signal_calculation.calculate_far_field_dipole_signal_time_kernel[BPG_ff, TPB_ff](
+                            cache["x"], cache["y"], cache["z"],
+                            cache["q"],
+                            pixel_x_ff, pixel_y_ff,
+                            pixel_categories_ff,
+                            mesh_params.CHARGE_NEIGHBOR_RADIUS * detector.PIXEL_PITCH,
+                            voxel_radius,
+                            z_anode,
+                            z_cathode,
+                            detector.V_DRIFT,
+                            detector.TIME_SAMPLING,
+                            5,
+                            mesh_params.INDUCED_CURRENT_SCALE,
+                            ff_signals
+                        )
+                    else:
+                        tpc_tracks = all_selected_tracks[all_selected_tracks['pixel_plane'] == tpc_idx]
+                        if len(tpc_tracks) == 0:
+                            continue
+                        signal_calculation.calculate_far_field_segment_signal_time_kernel[BPG_ff, TPB_ff](
+                            tpc_tracks,
+                            pixel_x_ff, pixel_y_ff,
+                            float(mesh_params.CHARGE_NEIGHBOR_RADIUS * detector.PIXEL_PITCH),
+                            float(mesh_params.FAR_FIELD_SEGMENT_STEP_CM),
+                            z_anode,
+                            z_cathode,
+                            detector.V_DRIFT,
+                            detector.TIME_SAMPLING,
+                            5,
+                            mesh_params.INDUCED_CURRENT_SCALE,
+                            ff_signals
+                        )
 
                     # Offset FF by event's min(t0) before digitization; normalize units if needed
                     min_t0_event = float(t0_array.min())
@@ -1546,6 +1574,8 @@ def run_simulation(input_filename,
                     time_ticks = cp.arange(0, len(unique_eventIDs) * max_signal_time, detector.TIME_SAMPLING)
                     integral_list = cp.zeros((pixels_signals.shape[0], sim.MAX_ADC_VALUES))
                     adc_ticks_list = cp.zeros((pixels_signals.shape[0], sim.MAX_ADC_VALUES))
+
+                    # np.savez(f'sig_{ievd}_ff.npz', signals=pixels_signals, pixels=induction_pix_ids)
 
                     TPB_local = 4
                     BPG_local = ceil(pixels_signals.shape[0] / TPB_local)

--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -57,7 +57,7 @@ RESPONSE_BIN_SIZE = 0.04434
 #: The longest cathode charge response in time :math:`\mu s`
 RESPONSE_MAX_TIME = 0.0
 #: The maximum radius to consider the neighbouring charge response
-MAX_RADIUS = 4
+MAX_RADIUS = 2
 #: The step size to chop up segments :math:`cm`
 #: MIN_STEP_SIZE should be comparable to the smallest bin size in x,y,t of the response file
 #: The bin size in x, y is ~0.04 cm (1/10 of a pixel size),

--- a/larndsim/consts/mesh_params.py
+++ b/larndsim/consts/mesh_params.py
@@ -26,8 +26,11 @@ CHARGE_NEIGHBOR_RADIUS = 2  # pixels
 # Maximum induction consideration distance
 INDUCTION_CUTOFF_RADIUS = 50 # cm
 
+# Far-field segment split step size (1 mm)
+FAR_FIELD_SEGMENT_STEP_CM = 0.5  # cm
+
 # Minimum induction signal threshold (electrons)
-INDUCTION_SIGNAL_THRESHOLD = 1000.0  # e-
+INDUCTION_SIGNAL_THRESHOLD = 2000.0  # e-
 
 ####################################
 # Induced Current Normalization
@@ -40,13 +43,14 @@ INDUCED_CURRENT_SCALE = 0.03
 def set_mesh_parameters(voxel_size_x=None, voxel_size_y=None, voxel_size_t=None, 
                         charge_collection_radius=None, charge_neighbor_radius=None, 
                         induction_cutoff_radius=None, induction_signal_threshold=None,
-                        induced_current_scale=None):
+                        induced_current_scale=None, far_field_segment_step_cm=None):
     """
     To be updated to read from YAML
     """
     global COARSE_VOXEL_SIZE_X, COARSE_VOXEL_SIZE_Y, COARSE_VOXEL_SIZE_Z
     global CHARGE_COLLECTION_RADIUS, CHARGE_NEIGHBOR_RADIUS
     global INDUCTION_CUTOFF_RADIUS, INDUCTION_SIGNAL_THRESHOLD, INDUCED_CURRENT_SCALE
+    global FAR_FIELD_SEGMENT_STEP_CM
     
     if voxel_size_x is not None:
         COARSE_VOXEL_SIZE_X = voxel_size_x
@@ -64,3 +68,5 @@ def set_mesh_parameters(voxel_size_x=None, voxel_size_y=None, voxel_size_t=None,
         INDUCTION_SIGNAL_THRESHOLD = induction_signal_threshold
     if induced_current_scale is not None:
         INDUCED_CURRENT_SCALE = induced_current_scale
+    if far_field_segment_step_cm is not None:
+        FAR_FIELD_SEGMENT_STEP_CM = far_field_segment_step_cm

--- a/larndsim/mesh_refinement/signal_calculation.py
+++ b/larndsim/mesh_refinement/signal_calculation.py
@@ -149,6 +149,130 @@ def calculate_far_field_dipole_signal_time_kernel(
     output[p_idx, t_idx] = total_current
 
 
+@cuda.jit
+def calculate_far_field_segment_signal_time_kernel(
+    tracks,
+    pixel_x, pixel_y,
+    exclude_radius,
+    split_step_cm,
+    z_anode, z_cathode,
+    v_drift,
+    tick_size,
+    n_terms,
+    C,
+    output
+):
+    """
+    CUDA kernel: Calculate far-field induced current for each (pixel, tick)
+    by summing over segment contributions outside exclude_radius.
+
+    Long segments are split into pieces of roughly split_step_cm and each
+    piece contributes as a point charge located at the piece midpoint.
+
+    Args:
+        tracks: structured track array (fields: x_start, y_start, z_start,
+                x_end, y_end, z_end, n_electrons, pixel_plane, ...)
+    """
+    p_idx, t_idx = cuda.grid(2)
+    n_pixels = pixel_x.shape[0]
+    n_ticks = output.shape[1]
+    if p_idx >= n_pixels or t_idx >= n_ticks:
+        return
+
+    x_pixel = pixel_x[p_idx]
+    y_pixel = pixel_y[p_idx]
+    t = t_idx * tick_size
+    total_current = 0.0
+
+    n_segments = tracks.shape[0]
+    l = abs(z_cathode - z_anode)
+
+    for s_idx in range(n_segments):
+        segment = tracks[s_idx]
+        x0 = segment['x_start']
+        y0 = segment['y_start']
+        z0_seg = segment['z_start']
+        x1 = segment['x_end']
+        y1 = segment['y_end']
+        z1 = segment['z_end']
+
+        # skip before splitting into sub-pieces.
+        if exclude_radius > 0.0:
+            dx0 = abs(x0 - x_pixel)
+            dy0 = abs(y0 - y_pixel)
+            dx1 = abs(x1 - x_pixel)
+            dy1 = abs(y1 - y_pixel)
+            if max(dx0, dx1) <= exclude_radius and max(dy0, dy1) <= exclude_radius:
+                continue
+
+        vx = x1 - x0
+        vy = y1 - y0
+        vz = z1 - z0_seg
+        seg_len_sq = vx*vx + vy*vy + vz*vz
+        if seg_len_sq <= 1e-20:
+            continue
+        seg_len = math.sqrt(seg_len_sq)
+
+        n_split = 1
+        if split_step_cm > 0.0:
+            n_split = int(math.ceil(seg_len / split_step_cm))
+            if n_split < 1:
+                n_split = 1
+
+        q_piece = segment['n_electrons'] / n_split
+
+        for i_split in range(n_split):
+            frac = (i_split + 0.5) / n_split
+            x = x0 + frac * vx
+            y = y0 + frac * vy
+            z_start_piece = z0_seg + frac * vz
+
+            # far-field exclusion radius
+            if exclude_radius > 0.0:
+                dx_xy = abs(x - x_pixel)
+                dy_xy = abs(y - y_pixel)
+                if dx_xy <= exclude_radius or dy_xy <= exclude_radius:
+                    continue
+
+            drift_distance = v_drift * t
+            if z_start_piece > z_anode:
+                z = z_start_piece - drift_distance
+                if z < z_anode:
+                    continue
+            else:
+                z = z_start_piece + drift_distance
+                if z > z_anode:
+                    continue
+
+            dx = x - x_pixel
+            dy = y - y_pixel
+            dz = z - z_anode
+            r_sq = dx*dx + dy*dy + dz*dz
+            if r_sq < 1e-20:
+                continue
+            r = math.sqrt(r_sq)
+
+            term0 = (r_sq - 3.0*dz*dz) / (r_sq*r_sq*r)
+            term_sum = 0.0
+            for n in range(1, n_terms+1):
+                dz_p = dz + 2*n*l
+                r_p_sq = dx*dx + dy*dy + dz_p*dz_p
+                if r_p_sq > 1e-20:
+                    r_p = math.sqrt(r_p_sq)
+                    term_sum += (r_p_sq - 3.0*dz_p*dz_p) / (r_p_sq*r_p_sq*r_p)
+
+                dz_m = dz - 2*n*l
+                r_m_sq = dx*dx + dy*dy + dz_m*dz_m
+                if r_m_sq > 1e-20:
+                    r_m = math.sqrt(r_m_sq)
+                    term_sum += (r_m_sq - 3.0*dz_m*dz_m) / (r_m_sq*r_m_sq*r_m)
+
+            dWdz = C * (term0 + term_sum)
+            total_current += -q_piece * v_drift * dWdz
+
+    output[p_idx, t_idx] = total_current
+
+
 def launch_far_field_dipole_signal_calculation(
     voxel_pos, pixel_pos, voxel_charge, pixel_categories, z_anode, z_cathode, v_drift, tick_size, n_ticks, 
     n_terms=5, C=None, bx=16, by=16, exclude_radius=0.0, voxel_size_xy=None


### PR DESCRIPTION
This PR adds a new far-field simulation mode to evaluate the impact of voxelization on induced-current modeling. In addition to the existing voxel-based far-field path, the code can now compute far-field induced current directly from track segments outside the near-field region (after breaking them down into 5-mm subsegments). This mode is enabled via: `--farfield_enabled --farfield_mode segments`

The PR also reduces `MAX_RADIUS` to 2 pixels, so the dipole-based far-field calculation is applied immediately beyond that distance. The motivation is to recover contributions that can be missed in the detailed LUT-based path due to its cap on the number of segments contributing per pixel. The far-field dipole calculation does not have this per-pixel segment cap, which improves the response for denser events and at larger distances.