### PR TITLE
Fix the padding of the pixel response

### DIFF
--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -432,10 +432,10 @@ def load_response(response_file):
 
     if drift_ticks_diff > 0: # response is too long, chop
         response = response[drift_ticks_diff:]
-        warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses drift_length of {res_drift_length} cm; The response drfit_length is too long, chop {drift_ticks_diff} values at the beginning (close to the readout).')
+        warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses a drift_length of {res_drift_length} cm; The response drift_length is too long, chop {drift_ticks_diff} values at the beginning (close to the readout).')
     elif drift_ticks_diff < 0: # response is too short, pad
         response = cp.pad(response, ((0, 0), (0, 0), (abs(drift_ticks_diff), 0)))
-        warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses drift_length of {res_drift_length} cm; The response drfit_length is too short, pad {drift_ticks_diff} 0s at the beginning (close to the readout).')
+        warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses a drift_length of {res_drift_length} cm; The response drift_length is too short, pad {abs(drift_ticks_diff)} 0s at the beginning (close to the readout).')
 
     RESPONSE_MAX_TIME = float(cp.max(cp.nonzero(response)[2]) * RESPONSE_SAMPLING) # axis 0,1 are pixel plane bins, and axis 2 is the time axis
 

--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -434,7 +434,7 @@ def load_response(response_file):
         response = response[drift_ticks_diff:]
         warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses drift_length of {res_drift_length} cm; The response drfit_length is too long, chop {drift_ticks_diff} values at the beginning (close to the readout).')
     elif drift_ticks_diff < 0: # response is too short, pad
-        response = cp.pad(response, abs(drift_ticks_diff))
+        response = cp.pad(response, ((0, 0), (0, 0), (abs(drift_ticks_diff), 0)))
         warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses drift_length of {res_drift_length} cm; The response drfit_length is too short, pad {drift_ticks_diff} 0s at the beginning (close to the readout).')
 
     RESPONSE_MAX_TIME = float(cp.max(cp.nonzero(response)[2]) * RESPONSE_SAMPLING) # axis 0,1 are pixel plane bins, and axis 2 is the time axis


### PR DESCRIPTION
The field response is represented as a 3D array with dimensions *(x, y, t)*. When the configured drift distance exceeds that covered by the field response, the response must be extended along the time axis to represent the additional drift.

The current implementation:

```python
cp.pad(response, abs(drift_ticks_diff))
```

pads all axes symmetrically (both before and after each dimension), which is incorrect for this use case (see [documentation](https://docs.cupy.dev/en/latest/reference/generated/cupy.pad.html)).


Instead, we should only pad the time axis, and only on the left side:

```python
cp.pad(response, ((0, 0), (0, 0), (abs(drift_ticks_diff), 0)))
```

This preserves the spatial dimensions along the pixel plane *(x, y)* and correctly applies a shift in time by adding zeros at the beginning of the waveform.
