### PR TITLE
Fix the trimming of the pixel response

### DIFF
--- a/larndsim/consts/detector.py
+++ b/larndsim/consts/detector.py
@@ -431,7 +431,7 @@ def load_response(response_file):
     drift_ticks_diff = round((res_drift_length - DRIFT_LENGTH) / V_DRIFT / RESPONSE_SAMPLING) # time difference of the response file vs. the TPC in terms of response time ticks
 
     if drift_ticks_diff > 0: # response is too long, chop
-        response = response[drift_ticks_diff:]
+        response = response[:, :, drift_ticks_diff:]
         warnings.warn(f'The TPC drift_length is {DRIFT_LENGTH} cm and the charge response simulation uses drift_length of {res_drift_length} cm; The response drfit_length is too long, chop {drift_ticks_diff} values at the beginning (close to the readout).')
     elif drift_ticks_diff < 0: # response is too short, pad
         response = cp.pad(response, abs(drift_ticks_diff))


### PR DESCRIPTION
As discussed in #318, the field response is represented as a 3D array with dimensions *(x, y, t)*. When the configured drift length differs from the coverage of the field response, the array must be adjusted along the time axis (either padded or trimmed) to maintain consistency.

The current implementation incorrectly trims the first dimension, which corresponds to the spatial position on the pixel plane. Instead, the adjustment should be applied to the third dimension (the time axis). This PR fixes the issue by trimming along the time axis and preserving the spatial dimensions *(x, y)*.

Note: This bug does **not** seem to affect existing simulation configurations and samples. 