### PR TITLE
Adding 2x2 cosmic configuration

### DIFF
--- a/larndsim/config/config.yaml
+++ b/larndsim/config/config.yaml
@@ -73,6 +73,10 @@ module0:
     <<: *2x2modvar
     SIM_PROPERTIES:  singles_sim.yaml
 
+2x2_cosmic:
+    <<: *2x2modvar
+    SIM_PROPERTIES:  cosmic_sim.yaml
+
 # nd-lar (same module configuration)
 ndlar: &ndlarmain
     SIM_PROPERTIES:  NDLAr_LBNF_sim.yaml


### PR DESCRIPTION
Added cosmic configuration to config files. Most recent talk about 2x2 cosmic sim is in: 
- https://docs.dunescience.org/cgi-bin/sso/ShowDocument?docid=36780
A comparison of track angles between 2x2 run 1 cosmics and the CORSIKA based cosmic sim:
<img width="627" height="566" alt="image" src="https://github.com/user-attachments/assets/2593d693-9827-4ce6-9e7e-4a2912c56462" />
